### PR TITLE
Project fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Rider
+.idea/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(SolutionDir)packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props" Condition="Exists('$(SolutionDir)packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props')" />
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
         <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -36,13 +35,13 @@
     </PropertyGroup>
     <Target Name="Publicise" AfterTargets="Clean">
         <ItemGroup>
-            <PubliciseInputAssemblies Include="$(WrathPath)\Wrath_Data\Managed\Assembly-CSharp.dll" />
-            <PubliciseInputAssemblies Include="$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.UI.dll" />
+            <PubliciseInputAssemblies Include="$(WrathPath)\Wrath_Data\Managed\Assembly-CSharp.dll"/>
+            <PubliciseInputAssemblies Include="$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.UI.dll"/>
         </ItemGroup>
-        <Publicise InputAssemblies="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/" PubliciseCompilerGenerated="true" />
+        <Publicise InputAssemblies="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/" PubliciseCompilerGenerated="true"/>
     </Target>
     <ItemGroup>
-        <PackageReference Include="Aze.Publicise.MSBuild.Task" Version="1.0.0" />
+        <PackageReference Include="Aze.Publicise.MSBuild.Task" Version="1.0.0"/>
         <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
             <HintPath>$(WrathPath)\Wrath_Data\Managed\0Harmony.dll</HintPath>
             <Private>False</Private>
@@ -55,8 +54,8 @@
             <HintPath>$(WrathPath)\Wrath_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="Microsoft.Build.Framework" />
-        <Reference Include="Microsoft.Build.Utilities.v4.0" />
+        <Reference Include="Microsoft.Build.Framework"/>
+        <Reference Include="Microsoft.Build.Utilities.v4.0"/>
         <Reference Include="Owlcat.Runtime.Core">
             <HintPath>$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.Core.dll</HintPath>
             <Private>False</Private>
@@ -68,14 +67,14 @@
             <HintPath>$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.Visual.dll</HintPath>
             <Private>False</Private>
         </Reference>
-        <Reference Include="System" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Xml.Linq" />
-        <Reference Include="System.Data.DataSetExtensions" />
-        <Reference Include="Microsoft.CSharp" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Net.Http" />
-        <Reference Include="System.Xml" />
+        <Reference Include="System"/>
+        <Reference Include="System.Core"/>
+        <Reference Include="System.Xml.Linq"/>
+        <Reference Include="System.Data.DataSetExtensions"/>
+        <Reference Include="Microsoft.CSharp"/>
+        <Reference Include="System.Data"/>
+        <Reference Include="System.Net.Http"/>
+        <Reference Include="System.Xml"/>
         <Reference Include="UniRx">
             <HintPath>$(WrathPath)\Wrath_Data\Managed\UniRx.dll</HintPath>
         </Reference>
@@ -124,53 +123,53 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
-        <Compile Include="classes\Infrastructure\Borrowed\StateReplacer.cs" />
-        <Compile Include="classes\Infrastructure\HotkeyHelper.cs" />
-        <Compile Include="classes\Infrastructure\WrathExtensions.cs" />
-        <Compile Include="classes\Infrastructure\BlueprintExtensions.cs" />
-        <Compile Include="classes\MainUI\MulticlassPicker.cs" />
-        <Compile Include="classes\MainUI\LevelUp.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Appearance.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\ModUI.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\NewChar.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\NoFriendlyFire.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\DiceRolls.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Multipliers.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Selectors.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\LevelUp.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Tweaks.cs" />
-        <Compile Include="classes\MonkeyPatchin\MoveThroughOthers.cs" />
-        <Compile Include="classes\MainUI\BlueprintAction.cs" />
-        <Compile Include="classes\Infrastructure\Borrowed\Accessors.cs" />
-        <Compile Include="classes\Infrastructure\Borrowed\PartyUtils.cs" />
-        <Compile Include="classes\MonkeyPatchin\Multiclass\General.cs" />
-        <Compile Include="classes\MonkeyPatchin\Multiclass\MultipleClasses.cs" />
-        <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\HP.cs" />
-        <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\SavesBAB.cs" />
-        <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\SkillPoint.cs" />
-        <Compile Include="classes\MonkeyPatchin\PreviewManager.cs" />
-        <Compile Include="classes\Infrastructure\UnitEntityDetails.cs" />
-        <Compile Include="classes\MonkeyPatchin\PreviewUtilities.cs" />
-        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Misc.cs" />
-        <Compile Include="classes\MonkeyPatchin\HighlightObjectToggle.cs" />
-        <Compile Include="classes\MainUI\Actions.cs" />
-        <Compile Include="classes\MainUI\BlueprintListUI.cs" />
-        <Compile Include="classes\MainUI\BlueprintLoader.cs" />
-        <Compile Include="classes\MainUI\ActionButtons.cs" />
-        <Compile Include="classes\MainUI\FactsEditor.cs" />
-        <Compile Include="classes\MainUI\Main.cs" />
-        <Compile Include="classes\MainUI\BlueprintBrowser.cs" />
-        <Compile Include="classes\MainUI\CheapTricks.cs" />
-        <Compile Include="classes\MainUI\CharacterPicker.cs" />
-        <Compile Include="classes\MainUI\QuestEditor.cs" />
-        <Compile Include="classes\MainUI\PartyEditor.cs" />
-        <Compile Include="classes\MonkeyPatchin\Multiclass\Mod.cs" />
-        <Compile Include="classes\MonkeyPatchin\Multiclass\WrathExtensionsMulticlass.cs" />
-        <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="classes\Models\Settings.cs" />
+        <Compile Include="classes\Infrastructure\Borrowed\StateReplacer.cs"/>
+        <Compile Include="classes\Infrastructure\HotkeyHelper.cs"/>
+        <Compile Include="classes\Infrastructure\WrathExtensions.cs"/>
+        <Compile Include="classes\Infrastructure\BlueprintExtensions.cs"/>
+        <Compile Include="classes\MainUI\MulticlassPicker.cs"/>
+        <Compile Include="classes\MainUI\LevelUp.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Appearance.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\ModUI.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\NewChar.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\NoFriendlyFire.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\DiceRolls.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Multipliers.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Selectors.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\LevelUp.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Tweaks.cs"/>
+        <Compile Include="classes\MonkeyPatchin\MoveThroughOthers.cs"/>
+        <Compile Include="classes\MainUI\BlueprintAction.cs"/>
+        <Compile Include="classes\Infrastructure\Borrowed\Accessors.cs"/>
+        <Compile Include="classes\Infrastructure\Borrowed\PartyUtils.cs"/>
+        <Compile Include="classes\MonkeyPatchin\Multiclass\General.cs"/>
+        <Compile Include="classes\MonkeyPatchin\Multiclass\MultipleClasses.cs"/>
+        <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\HP.cs"/>
+        <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\SavesBAB.cs"/>
+        <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\SkillPoint.cs"/>
+        <Compile Include="classes\MonkeyPatchin\PreviewManager.cs"/>
+        <Compile Include="classes\Infrastructure\UnitEntityDetails.cs"/>
+        <Compile Include="classes\MonkeyPatchin\PreviewUtilities.cs"/>
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Misc.cs"/>
+        <Compile Include="classes\MonkeyPatchin\HighlightObjectToggle.cs"/>
+        <Compile Include="classes\MainUI\Actions.cs"/>
+        <Compile Include="classes\MainUI\BlueprintListUI.cs"/>
+        <Compile Include="classes\MainUI\BlueprintLoader.cs"/>
+        <Compile Include="classes\MainUI\ActionButtons.cs"/>
+        <Compile Include="classes\MainUI\FactsEditor.cs"/>
+        <Compile Include="classes\MainUI\Main.cs"/>
+        <Compile Include="classes\MainUI\BlueprintBrowser.cs"/>
+        <Compile Include="classes\MainUI\CheapTricks.cs"/>
+        <Compile Include="classes\MainUI\CharacterPicker.cs"/>
+        <Compile Include="classes\MainUI\QuestEditor.cs"/>
+        <Compile Include="classes\MainUI\PartyEditor.cs"/>
+        <Compile Include="classes\MonkeyPatchin\Multiclass\Mod.cs"/>
+        <Compile Include="classes\MonkeyPatchin\Multiclass\WrathExtensionsMulticlass.cs"/>
+        <Compile Include="Properties\AssemblyInfo.cs"/>
+        <Compile Include="classes\Models\Settings.cs"/>
     </ItemGroup>
     <ItemGroup>
-        <None Include=".editorconfig" />
+        <None Include=".editorconfig"/>
         <None Include="Repository.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
@@ -179,14 +178,14 @@
         </None>
     </ItemGroup>
     <ItemGroup>
-        <Compile Include="zmisc\Snippets.cs" />
+        <Compile Include="zmisc\Snippets.cs"/>
     </ItemGroup>
     <ItemGroup>
-        <Content Include="README.txt" />
-        <Content Include="zmisc\api.txt" />
+        <Content Include="README.txt"/>
+        <Content Include="zmisc\api.txt"/>
     </ItemGroup>
-    <Import Project="$(SolutionDir)ModKit\ModKitSrc.projitems" Label="Shared" />
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <Import Project="$(SolutionDir)ModKit\ModKitSrc.projitems" Label="Shared"/>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
     <PropertyGroup>
         <PostBuildEvent>echo "$(TargetPath)" "&gt;$(WrathPath)\Mods\0$(ProjectName)0\$(ProjectName).dll*"
             xcopy /Y "$(TargetPath)" "$(WrathPath)\Mods\0$(ProjectName)0\$(ProjectName).dll"

--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -1,216 +1,197 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props" Condition="Exists('..\packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{22DCB4E1-D979-4EA9-913A-4EE1634B4DED}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ToyBox</RootNamespace>
-    <AssemblyName>ToyBox</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>false</Deterministic>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\0ToyBox0\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>none</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\0ToyBox0\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup>
-    <WrathInstallDir Condition=" '$(WrathInstallDir)' == '' ">C:\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure</WrathInstallDir>
-  </PropertyGroup>
-  <Target Name="Publicise" AfterTargets="Clean">
-    <ItemGroup>
-      <PubliciseInputAssemblies Include="$(WrathInstallDir)\Wrath_Data\Managed\Assembly-CSharp.dll" />
-      <PubliciseInputAssemblies Include="$(WrathInstallDir)\Wrath_Data\Managed\Owlcat.Runtime.UI.dll" />
-    </ItemGroup>
-    <Publicise InputAssemblies="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/" PubliciseCompilerGenerated="true" />
-  </Target>
-  <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.0.4\lib\net472\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>$(SolutionDir)lib\Assembly-CSharp_public.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="Owlcat.Runtime.Core">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\Owlcat.Runtime.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Owlcat.Runtime.UI_public">
-      <HintPath>..\lib\Owlcat.Runtime.UI_public.dll</HintPath>
-    </Reference>
-    <Reference Include="Owlcat.Runtime.Visual">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\Owlcat.Runtime.Visual.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="UniRx">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UniRx.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.InputModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.InputModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityEngine.UIModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityModManager">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\UnityModManager\UnityModManager.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="classes\Infrastructure\Borrowed\StateReplacer.cs" />
-    <Compile Include="classes\Infrastructure\HotkeyHelper.cs" />
-    <Compile Include="classes\Infrastructure\WrathExtensions.cs" />
-    <Compile Include="classes\Infrastructure\BlueprintExtensions.cs" />
-    <Compile Include="classes\MainUI\MulticlassPicker.cs" />
-    <Compile Include="classes\MainUI\LevelUp.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\Appearance.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\ModUI.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\NewChar.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\NoFriendlyFire.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\DiceRolls.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\Multipliers.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\Selectors.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\LevelUp.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\Tweaks.cs" />
-    <Compile Include="classes\MonkeyPatchin\MoveThroughOthers.cs" />
-    <Compile Include="classes\MainUI\BlueprintAction.cs" />
-    <Compile Include="classes\Infrastructure\Borrowed\Accessors.cs" />
-    <Compile Include="classes\Infrastructure\Borrowed\PartyUtils.cs" />
-    <Compile Include="classes\MonkeyPatchin\Multiclass\General.cs" />
-    <Compile Include="classes\MonkeyPatchin\Multiclass\MultipleClasses.cs" />
-    <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\HP.cs" />
-    <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\SavesBAB.cs" />
-    <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\SkillPoint.cs" />
-    <Compile Include="classes\MonkeyPatchin\PreviewManager.cs" />
-    <Compile Include="classes\Infrastructure\UnitEntityDetails.cs" />
-    <Compile Include="classes\MonkeyPatchin\PreviewUtilities.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\Misc.cs" />
-    <Compile Include="classes\MonkeyPatchin\HighlightObjectToggle.cs" />
-    <Compile Include="classes\MainUI\Actions.cs" />
-    <Compile Include="classes\MainUI\BlueprintListUI.cs" />
-    <Compile Include="classes\MainUI\BlueprintLoader.cs" />
-    <Compile Include="classes\MainUI\ActionButtons.cs" />
-    <Compile Include="classes\MainUI\FactsEditor.cs" />
-    <Compile Include="classes\MainUI\Main.cs" />
-    <Compile Include="classes\MainUI\BlueprintBrowser.cs" />
-    <Compile Include="classes\MainUI\CheapTricks.cs" />
-    <Compile Include="classes\MainUI\CharacterPicker.cs" />
-    <Compile Include="classes\MainUI\QuestEditor.cs" />
-    <Compile Include="classes\MainUI\PartyEditor.cs" />
-    <Compile Include="classes\MonkeyPatchin\Multiclass\Mod.cs" />
-    <Compile Include="classes\MonkeyPatchin\Multiclass\WrathExtensionsMulticlass.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="classes\Models\Settings.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include=".editorconfig" />
-    <None Include="packages.config" />
-    <None Include="Repository.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Info.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="zmisc\Snippets.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="README.txt" />
-    <Content Include="zmisc\api.txt" />
-  </ItemGroup>
-  <Import Project="..\ModKit\ModKitSrc.projitems" Label="Shared" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <ProjectExtensions>
-    <VisualStudio>
-      <UserProperties info_1json__JsonSchema="" />
-    </VisualStudio>
-  </ProjectExtensions>
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <Import Project="$(SolutionDir)packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props" Condition="Exists('$(SolutionDir)packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props')" />
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{22DCB4E1-D979-4EA9-913A-4EE1634B4DED}</ProjectGuid>
+        <OutputType>Library</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>ToyBox</RootNamespace>
+        <AssemblyName>ToyBox</AssemblyName>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+        <Deterministic>false</Deterministic>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Aze.Publicise.MSBuild.Task.1.0.0\build\Aze.Publicise.MSBuild.Task.props'))" />
-  </Target>
-  <PropertyGroup>
-    <PostBuildEvent>echo "$(TargetPath)" "&gt;C:\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Mods\0$(ProjectName)0\$(ProjectName).dll*"
-xcopy /Y "$(TargetPath)" "C:\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Mods\0$(ProjectName)0\$(ProjectName).dll"
-xcopy /Y "$(TargetDir)$(TargetName).pdb" "C:\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Mods\0$(ProjectName)0\$(ProjectName).pdb"
-</PostBuildEvent>
-  </PropertyGroup>
-  <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
-  </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\0ToyBox0\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>none</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\0ToyBox0\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    </PropertyGroup>
+    <Target Name="Publicise" AfterTargets="Clean">
+        <ItemGroup>
+            <PubliciseInputAssemblies Include="$(WrathPath)\Wrath_Data\Managed\Assembly-CSharp.dll" />
+            <PubliciseInputAssemblies Include="$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.UI.dll" />
+        </ItemGroup>
+        <Publicise InputAssemblies="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/" PubliciseCompilerGenerated="true" />
+    </Target>
+    <ItemGroup>
+        <PackageReference Include="Lib.Harmony" Version="2.1.1" />
+        <PackageReference Include="Aze.Publicise.MSBuild.Task" Version="1.0.0" />
+        <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\0Harmony.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Assembly-CSharp">
+            <HintPath>$(SolutionDir)lib\Assembly-CSharp_public.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Assembly-CSharp-firstpass">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.Build.Framework" />
+        <Reference Include="Microsoft.Build.Utilities.v4.0" />
+        <Reference Include="Owlcat.Runtime.Core">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.Core.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Owlcat.Runtime.UI_public">
+            <HintPath>$(SolutionDir)lib\Owlcat.Runtime.UI_public.dll</HintPath>
+        </Reference>
+        <Reference Include="Owlcat.Runtime.Visual">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.Visual.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Xml.Linq" />
+        <Reference Include="System.Data.DataSetExtensions" />
+        <Reference Include="Microsoft.CSharp" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Net.Http" />
+        <Reference Include="System.Xml" />
+        <Reference Include="UniRx">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UniRx.dll</HintPath>
+        </Reference>
+        <Reference Include="Unity.TextMeshPro">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityEngine.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.AssetBundleModule">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.CoreModule">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.IMGUIModule">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.InputLegacyModule">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.InputModule">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityEngine.InputModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.TextRenderingModule">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.UI">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityEngine.UI.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.UIModule">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityModManager">
+            <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityModManager\UnityModManager.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="classes\Infrastructure\Borrowed\StateReplacer.cs" />
+        <Compile Include="classes\Infrastructure\HotkeyHelper.cs" />
+        <Compile Include="classes\Infrastructure\WrathExtensions.cs" />
+        <Compile Include="classes\Infrastructure\BlueprintExtensions.cs" />
+        <Compile Include="classes\MainUI\MulticlassPicker.cs" />
+        <Compile Include="classes\MainUI\LevelUp.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Appearance.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\ModUI.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\NewChar.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\NoFriendlyFire.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\DiceRolls.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Multipliers.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Selectors.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\LevelUp.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Tweaks.cs" />
+        <Compile Include="classes\MonkeyPatchin\MoveThroughOthers.cs" />
+        <Compile Include="classes\MainUI\BlueprintAction.cs" />
+        <Compile Include="classes\Infrastructure\Borrowed\Accessors.cs" />
+        <Compile Include="classes\Infrastructure\Borrowed\PartyUtils.cs" />
+        <Compile Include="classes\MonkeyPatchin\Multiclass\General.cs" />
+        <Compile Include="classes\MonkeyPatchin\Multiclass\MultipleClasses.cs" />
+        <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\HP.cs" />
+        <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\SavesBAB.cs" />
+        <Compile Include="classes\MonkeyPatchin\Multiclass\StatProgression\SkillPoint.cs" />
+        <Compile Include="classes\MonkeyPatchin\PreviewManager.cs" />
+        <Compile Include="classes\Infrastructure\UnitEntityDetails.cs" />
+        <Compile Include="classes\MonkeyPatchin\PreviewUtilities.cs" />
+        <Compile Include="classes\MonkeyPatchin\BagOfPatches\Misc.cs" />
+        <Compile Include="classes\MonkeyPatchin\HighlightObjectToggle.cs" />
+        <Compile Include="classes\MainUI\Actions.cs" />
+        <Compile Include="classes\MainUI\BlueprintListUI.cs" />
+        <Compile Include="classes\MainUI\BlueprintLoader.cs" />
+        <Compile Include="classes\MainUI\ActionButtons.cs" />
+        <Compile Include="classes\MainUI\FactsEditor.cs" />
+        <Compile Include="classes\MainUI\Main.cs" />
+        <Compile Include="classes\MainUI\BlueprintBrowser.cs" />
+        <Compile Include="classes\MainUI\CheapTricks.cs" />
+        <Compile Include="classes\MainUI\CharacterPicker.cs" />
+        <Compile Include="classes\MainUI\QuestEditor.cs" />
+        <Compile Include="classes\MainUI\PartyEditor.cs" />
+        <Compile Include="classes\MonkeyPatchin\Multiclass\Mod.cs" />
+        <Compile Include="classes\MonkeyPatchin\Multiclass\WrathExtensionsMulticlass.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="classes\Models\Settings.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include=".editorconfig" />
+        <None Include="Repository.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="Info.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="zmisc\Snippets.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <Content Include="README.txt" />
+        <Content Include="zmisc\api.txt" />
+    </ItemGroup>
+    <Import Project="$(SolutionDir)ModKit\ModKitSrc.projitems" Label="Shared" />
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <PropertyGroup>
+        <PostBuildEvent>echo "$(TargetPath)" "&gt;$(WrathPath)\Mods\0$(ProjectName)0\$(ProjectName).dll*"
+            xcopy /Y "$(TargetPath)" "$(WrathPath)\Mods\0$(ProjectName)0\$(ProjectName).dll"
+            xcopy /Y "$(TargetDir)$(TargetName).pdb" "$(WrathPath)\Mods\0$(ProjectName)0\$(ProjectName).pdb"
+        </PostBuildEvent>
+    </PropertyGroup>
 </Project>

--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -42,7 +42,6 @@
         <Publicise InputAssemblies="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/" PubliciseCompilerGenerated="true" />
     </Target>
     <ItemGroup>
-        <PackageReference Include="Lib.Harmony" Version="2.1.1" />
         <PackageReference Include="Aze.Publicise.MSBuild.Task" Version="1.0.0" />
         <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
             <HintPath>$(WrathPath)\Wrath_Data\Managed\0Harmony.dll</HintPath>

--- a/ToyBox/classes/Infrastructure/Borrowed/Accessors.cs
+++ b/ToyBox/classes/Infrastructure/Borrowed/Accessors.cs
@@ -7,6 +7,8 @@ using HarmonyLib;
 using System;
 using System.Linq;
 
+#pragma warning disable 618
+
 namespace ToyBox
 {
     public delegate TResult FastGetter<TClass, TResult>(TClass source);

--- a/ToyBox/classes/MainUI/Actions.cs
+++ b/ToyBox/classes/MainUI/Actions.cs
@@ -78,6 +78,7 @@ namespace ToyBox {
                 var info = infoRef.Get();
                 var etudeGUID = info.EtudeGuid;
                 var etudeBp = ResourcesLibrary.TryGetBlueprint<BlueprintEtude>(etudeGUID);
+                Main.Log($"mythicInfo: {info} {etudeGUID} {etudeBp}");
                 Game.Instance.Player.EtudesSystem.StartEtude(etudeBp);
             }
 #if false

--- a/ToyBox/packages.config
+++ b/ToyBox/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-	<package id="Lib.Harmony" version="2.0.4" targetFramework="net472" />
-  <package id="Aze.Publicise.MSBuild.Task" version="1.0.0" targetFramework="net472" developmentDependency="true" />
-</packages>


### PR DESCRIPTION
Changes:

- use project and environment variables: Add `WrathPath` to your user environment variables.
- replaced `packages.config` with `PackageReferences`: This is the way.
- removed `EnsureNuGetPackageBuildImports` target: This fails when the NuGet packages folder is not local.
- removed `Lib.Harmony` package: Wrath is distributed with `0Harmony.dll` so this is no longer needed.
- output full PDB for debug build
- ignore Rider user settings
- suppress obsolete warnings in `Accessors.cs`