### PR TITLE
fix unity manager update notification

### DIFF
--- a/ToyBox/Info.json
+++ b/ToyBox/Info.json
@@ -8,5 +8,5 @@
     "AssemblyName": "ToyBox.dll",
     "EntryMethod": "ToyBox.Main.Load",
     "HomePage": "https://www.nexusmods.com/pathfinderwrathoftherighteous/mods/8?tab=posts&BH=0",
-    "Repository": "https://github.com/cabarius/ToyBox/Repository.json"
+    "Repository": "https://raw.githubusercontent.com/cabarius/ToyBox/master/ToyBox/Repository.json"
 }

--- a/ToyBox/Repository.json
+++ b/ToyBox/Repository.json
@@ -3,7 +3,7 @@
 	[
 		{
 			"Id": "ToyBox",
-			"Version": "1.1.11"
+			"Version": "1.2.11"
 		}
 	]
 }


### PR DESCRIPTION
Fixed the link to the Repository json. The raw version can be parsed by the unity mod manager and properly displays when a new version is available.