### PR TITLE
After Army Battle Raise Multiplier

### DIFF
--- a/ToyBox/classes/MainUI/CheapTricks.cs
+++ b/ToyBox/classes/MainUI/CheapTricks.cs
@@ -231,6 +231,7 @@ namespace ToyBox {
                     UI.Space(328); UI.Label("Experimental: Increasing this may cause performance issues when rotating".green(), UI.AutoWidth());
                 },
                 () => UI.LogSlider("Game Time Scale", ref settings.timeScaleMultiplier, 0f, 20, 1, 2, "", UI.AutoWidth()),
+                () => UI.LogSlider("After Army Battle Raise Multiplier", ref settings.postBattleSummonMultiplier, 0f, 100, 1, 1, "", UI.AutoWidth()),
                 () => { }
                 );
             Game.Instance.TimeController.DebugTimeScale = settings.timeScaleMultiplier;

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -96,6 +96,7 @@ namespace ToyBox {
         public float fovMultiplier = 1;
         public float fovMultiplierMax = 1.25f;
         public float timeScaleMultiplier = 1;
+        public float postBattleSummonMultiplier = 1;
 
         // Dice Rolls
         public UnitSelectType allAttacksHit = UnitSelectType.Off;

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
@@ -45,6 +45,7 @@ using Kingmaker.Enums;
 using Kingmaker.Enums.Damage;
 using Kingmaker.Formations;
 using DG.Tweening;
+using Kingmaker.Armies.TacticalCombat;
 using Kingmaker.GameModes;
 using Kingmaker.Globalmap;
 using Kingmaker.Items;
@@ -125,6 +126,7 @@ using UnityModManager = UnityModManagerNet.UnityModManager;
 using Kingmaker.Globalmap.Blueprints;
 using Kingmaker.Globalmap.State;
 using Kingmaker.Globalmap.View;
+using Kingmaker.Kingdom.Buffs;
 using ModKit;
 
 namespace ToyBox.BagOfPatches {
@@ -328,6 +330,14 @@ namespace ToyBox.BagOfPatches {
                     Main.Debug("UnitSpawner.Spawn: " + __result.CharacterName);
                     __result.Stats.HitPoints.BaseValue = Mathf.RoundToInt(__result.Stats.HitPoints.BaseValue * settings.enemyBaseHitPointsMultiplier);
                 }
+            }
+        }
+
+        [HarmonyPatch(typeof(SummonUnitsAfterArmyBattle), "HandleArmiesBattleResultsApplied")]
+        public static class SummonUnitsAfterArmyBattle_Patch {
+            public static void Prefix(ref TacticalCombatResults results) {
+                results = new TacticalCombatResults(results.Attacker, results.Defender, Mathf.RoundToInt(results.BattleExp * settings.postBattleSummonMultiplier),
+                    results.CrusadeStatsBonus, results.Winner, results.ToResurrect, results.Units, results.Retreat);
             }
         }
 


### PR DESCRIPTION
Added a multiplier ('After Army Battle Raise Multiplier') for the number of units raised by Lich's Necromancy and similar effects. This code only gets triggered when players win, so shouldn't have any additional side effects.