### PR TITLE
Experimental - Large Player Armies

### DIFF
--- a/ToyBox/README.txt
+++ b/ToyBox/README.txt
@@ -11,6 +11,8 @@ Now with 260+ Cheats, Tweaks and Quality of Life Improvements
     Search 'n Pick: 75 ways to view, add, remove blueprints plus a fun global teleportation feature
     Quest Resolution: 1
 
+Ver 1.3.3
+    (ArcaneTrixter) Added an experimental "Large Player Armies" toggle to the Crusade tab, which will enable players to have up to 14 units in their army. This might have unintended side effects if reloading a game with large armies without this setting enabled.
 Ver 1.3.2
     Enemy armies no longer speed up with movement speed multiplier. Only your armies become speedsters ^_^
     Initial teleport to cursor for party and main character support.  Use comma ',' to teleport the party and '.' to teleport the main char

--- a/ToyBox/classes/MainUI/CrusadeEditor.cs
+++ b/ToyBox/classes/MainUI/CrusadeEditor.cs
@@ -1,4 +1,5 @@
-﻿using Kingmaker.Kingdom;
+﻿using Kingmaker.Blueprints.Root;
+using Kingmaker.Kingdom;
 using ModKit;
 
 namespace ToyBox.classes.MainUI {
@@ -16,6 +17,17 @@ namespace ToyBox.classes.MainUI {
             UI.Div(0, 25);
             UI.HStack("Army Edits", 1,
                 () => UI.Toggle("Infinite Mercenary Rerolls", ref Settings.toggleInfiniteArmyRerolls),
+                () => {
+                    UI.Toggle("Experimental - Enable Large Player Armies", ref Settings.toggleLargeArmies);
+                    if (Settings.toggleLargeArmies) {
+                        BlueprintRoot.Instance.Kingdom.StartArmySquadsCount = 14;
+                        BlueprintRoot.Instance.Kingdom.MaxArmySquadsCount = 14;
+                    }
+                    else {
+                        BlueprintRoot.Instance.Kingdom.StartArmySquadsCount = 4;
+                        BlueprintRoot.Instance.Kingdom.MaxArmySquadsCount = 7;
+                    }
+                },
                 () => UI.Slider("Recruitment Cost", ref Settings.recruitmentCost, 0f, 1f, 1f, 2, "", UI.AutoWidth()),
                 () => UI.LogSlider("Number of Recruits", ref Settings.recruitmentMultiplier, 0f, 100, 1, 1, "", UI.AutoWidth()),
 

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -48,10 +48,17 @@ namespace ToyBox {
         public bool toggleMultipleRomance = false;
         public bool toggleSpiderBegone = false;
         public bool togglAutoEquipConsumables = false;
-        public bool toggleInfiniteArmyRerolls = false;
         public bool toggleInstantChangeParty = false;
-        public bool toggleFlagsStayGreen = false;
 
+
+        //Crusade
+        public bool toggleInfiniteArmyRerolls = false;
+        public bool toggleLargeArmies = false;
+        public bool toggleFlagsStayGreen = false;
+        public float postBattleSummonMultiplier = 1;
+        public float recruitmentCost = 1;
+        public float recruitmentMultiplier = 1;
+        public float armyExperienceMultiplier = 1;
 
         // selectors
         public UnitSelectType noAttacksOfOpportunitySelection = UnitSelectType.Off;
@@ -83,7 +90,6 @@ namespace ToyBox {
         // Multipliers
         public int encumberanceMultiplier = 1;
         public float experienceMultiplier = 1;
-        public float armyExperienceMultiplier = 1;
         public float moneyMultiplier = 1;
         public float vendorSellPriceMultiplier = 1;
         public float vendorBuyPriceMultiplier = 1;
@@ -103,9 +109,6 @@ namespace ToyBox {
         public float fovMultiplier = 1;
         public float fovMultiplierMax = 1.25f;
         public float timeScaleMultiplier = 1;
-        public float postBattleSummonMultiplier = 1;
-        public float recruitmentCost = 1;
-        public float recruitmentMultiplier = 1;
 
         // Dice Rolls
         public UnitSelectType allAttacksHit = UnitSelectType.Off;

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Crusade.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Crusade.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Kingmaker.Armies;
 using Kingmaker.Armies.State;
 using Kingmaker.Armies.TacticalCombat;
 using Kingmaker.Blueprints.Root;
@@ -27,6 +28,20 @@ namespace ToyBox.classes.MonkeyPatchin.BagOfPatches {
             public static void Postfix(ref ArmyMercenariesManager __instance, int __state) {
                 if (Settings.toggleInfiniteArmyRerolls) {
                     __instance.FreeRerollsLeftCount = __state;
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(ArmyData), "MaxSquadsCount", MethodType.Getter)]
+        public static class ArmyData_MaxSquadsCount_Patch {
+            public static void Postfix(ref ArmyModifiableValue __result, ArmyData __instance) {
+                if (Settings.toggleLargeArmies && __result != null && __result.ModifiedValue != 0 && __instance.Faction == ArmyFaction.Crusaders) {
+                    __result.MaxValue = ArmyData.PositionsCount;
+                    __result.MinValue = ArmyData.PositionsCount;
+                    __result.m_BaseValue = __result.MaxValue;
+                    __result.ModifiedValue = __result.MaxValue;
+                    BlueprintRoot.Instance.Kingdom.StartArmySquadsCount = ArmyData.PositionsCount;
+                    BlueprintRoot.Instance.Kingdom.MaxArmySquadsCount = ArmyData.PositionsCount;
                 }
             }
         }


### PR DESCRIPTION
Added an experimental "Large Player Armies" toggle to the Crusade tab, which will enable players to have up to 14 units in their army. This might have unintended side effects if reloading a game with large armies without this setting enabled.

![large_army](https://user-images.githubusercontent.com/6569164/133266542-b88a354b-e8fa-4591-9007-f7e120f7c88e.png)
