### PR TITLE
Prevented negative burn which has weird side effects.

### DIFF
--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Tweaks.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Tweaks.cs
@@ -409,7 +409,7 @@ namespace ToyBox.BagOfPatches {
         [HarmonyPatch(typeof(KineticistAbilityBurnCost), "GetTotal")]
         public static class KineticistAbilityBurnCost_GetTotal_Patch {
             public static void Postfix(ref int __result) {
-                __result -= settings.kineticistBurnReduction;
+                __result = Math.Max(0, __result -settings.kineticistBurnReduction);
             }
         }
 


### PR DESCRIPTION
While I didn't notice on the character I was testing burn on, applying negative amounts of burn heals you (fine!) and then goes negative (and apparently has the same negative side effects as positive burn). Prevented.