### PR TITLE
Added an option to allow using legendary hero leveling for any

### DIFF
--- a/ToyBox/classes/MainUI/LevelUp.cs
+++ b/ToyBox/classes/MainUI/LevelUp.cs
@@ -63,6 +63,7 @@ namespace ToyBox {
                 () => UI.Toggle("Ignore Required Stat Values", ref settings.toggleIgnorePrerequisiteStatValue, 0),
                 () => UI.Toggle("Ignore Alignment When Choosing A Class", ref settings.toggleIgnoreAlignmentWhenChoosingClass, 0),
                 () => UI.Toggle("Skip Spell Selection", ref settings.toggleSkipSpellSelection, 0),
+                () => UI.Toggle("Always Use Legendary Hero Leveling", ref settings.toggleLegendaryLeveling, 0),
 #if DEBUG
                     () => UI.Toggle("Lock Character Level", ref settings.toggleLockCharacterLevel, 0),
                 //                    () => UI.Toggle("Ignore Alignment Restrictions", ref settings.toggleIgnoreAlignmentRestriction, 0),

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -89,6 +89,7 @@ namespace ToyBox {
         public bool toggleSkipSpellSelection = false;
         public bool toggleNextWhenNoAvailableFeatSelections = true;
         public bool toggleOptionalFeatSelection = false;
+        public bool toggleLegendaryLeveling = false;
 
         // Multipliers
         public int encumberanceMultiplier = 1;

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUp.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUp.cs
@@ -3,10 +3,12 @@
 using HarmonyLib;
 using JetBrains.Annotations;
 using Kingmaker;
+using Kingmaker.Blueprints;
 using Kingmaker.Blueprints.Classes;
 using Kingmaker.Blueprints.Classes.Prerequisites;
 using Kingmaker.Blueprints.Classes.Selection;
 using Kingmaker.Blueprints.Facts;
+using Kingmaker.Blueprints.Root;
 using Kingmaker.EntitySystem.Stats;
 using Kingmaker.UnitLogic;
 using Kingmaker.UnitLogic.Class.LevelUp;
@@ -29,6 +31,33 @@ namespace ToyBox.BagOfPatches {
             private static void Postfix(ref bool __result) {
                 if (settings.toggleNoLevelUpRestrictions) {
                     __result = true;
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(UnitProgressionData))]
+        static class UnitProgressionData_LegendaryHero_Patch {
+            [HarmonyPatch("ExperienceTable", MethodType.Getter)]
+            private static void Postfix(ref BlueprintStatProgression __result) {
+                __result = !settings.toggleLegendaryLeveling
+                        ? Game.Instance.BlueprintRoot.Progression.XPTable
+                        : Game.Instance.BlueprintRoot.Progression.LegendXPTable.Or(null)
+                          ?? Game.Instance.BlueprintRoot.Progression.XPTable;
+            }
+
+            [HarmonyPatch("MaxCharacterLevel", MethodType.Getter)]
+            private static void Postfix(ref int __result) {
+                if (settings.toggleLegendaryLeveling) {
+                    __result = 40;
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(ProgressionRoot), "XPTable", MethodType.Getter)]
+        static class ProgressionRoot_FixExperienceBar_Patch {
+            public static void Postfix(ref BlueprintStatProgression __result, ProgressionRoot __instance) {
+                if (settings.toggleLegendaryLeveling) {
+                    __result = __instance.LegendXPTable;
                 }
             }
         }


### PR DESCRIPTION
Addresses the multiple requests for allowing leveling past 20. Due to some technical limitations (specifically, you need a blueprint that specifies how much experience you need to level) we can't simply allow continued leveling past 20 in another easy way.