### PR TITLE
Initial Spellbook handler changes

### DIFF
--- a/ToyBox/README.txt
+++ b/ToyBox/README.txt
@@ -20,6 +20,7 @@ Ver 1.3.7
     Movement speed multiplier now affects when you interact with a map object or npc
     Coming soon - quick key support on Cheat Buttons in Bag of Tricks Tab
     (ArcaneTrixter) Added option to use legendary hero leveling as non-legends.
+    (ArcaneTrixter) Added a number of things around caster levels and spellbooks, including a +1/-1 caster level for any spellbook.
 Ver 1.3.6
     Fixed party speed multipliers to work with latest update of the game
     (ArcaneTrixter) Added requested multiplier for Arcanist spell slots.

--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -137,6 +137,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="classes\Infrastructure\Borrowed\StateReplacer.cs" />
+    <Compile Include="classes\Infrastructure\CasterHelpers.cs" />
     <Compile Include="classes\Infrastructure\Teleport.cs" />
     <Compile Include="classes\Infrastructure\Utils.cs" />
     <Compile Include="classes\Infrastructure\WrathExtensions.cs" />

--- a/ToyBox/classes/Infrastructure/CasterHelpers.cs
+++ b/ToyBox/classes/Infrastructure/CasterHelpers.cs
@@ -1,0 +1,102 @@
+﻿using Kingmaker.Blueprints;
+using Kingmaker.Blueprints.Classes;
+using Kingmaker.Blueprints.Classes.Selection;
+using Kingmaker.Blueprints.Classes.Spells;
+using Kingmaker.UnitLogic;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ToyBox.classes.Infrastructure {
+    public static class CasterHelpers {
+        public static Dictionary<UnitDescriptor, Dictionary<BlueprintSpellbook, int>> UnitBonusSpellLevels =
+            new Dictionary<UnitDescriptor, Dictionary<BlueprintSpellbook, int>>();
+        public static Dictionary<BlueprintSpellbook, int> GetOriginalCasterLevel(UnitDescriptor unit) {
+            Dictionary<BlueprintSpellbook, int> casterLevelDictionary = new Dictionary<BlueprintSpellbook, int>();
+            foreach (var classInfo in unit.Progression.Classes) {
+                if (classInfo.Spellbook == null) {
+                    continue;
+                }
+
+                int casterLevel = classInfo.Level + classInfo.Spellbook.CasterLevelModifier;
+
+                var skipLevels = classInfo.CharacterClass.GetComponent<SkipLevelsForSpellProgression>();
+                
+                if (skipLevels?.Levels?.Length > 0) {
+                    foreach (int skipLevelsLevel in skipLevels.Levels) {
+                        if (classInfo.Level >= skipLevelsLevel) { --casterLevel; }
+                    }
+                }
+
+                int levelToStartCountingFrom = classInfo.CharacterClass.PrestigeClass ? GetPrestigeCasterLevelStart(classInfo.CharacterClass.Progression) : 1;
+                casterLevel += 1 - levelToStartCountingFrom;
+
+                if (classInfo.Spellbook.IsMythic) {
+                    casterLevel *= 2;
+                }
+
+                if (casterLevelDictionary.ContainsKey(classInfo.Spellbook)) {
+                    casterLevelDictionary[classInfo.Spellbook] += casterLevel;
+                } else {
+                    casterLevelDictionary[classInfo.Spellbook] = casterLevel;
+                }
+            }
+#if DEBUG
+            foreach (var spellbook in casterLevelDictionary) {
+                Main.Log($"{spellbook.Key.Name}: {spellbook.Value}");
+            }
+#endif
+            return casterLevelDictionary;
+        }
+
+        public static int GetRealCasterLevel(UnitDescriptor unit, BlueprintSpellbook spellbook) {
+            GetOriginalCasterLevel(unit).TryGetValue(spellbook, out int level);
+            return level;
+        }
+
+        public static void FindBonusLevels(UnitDescriptor unit) {
+            var resultsDictionary = new Dictionary<BlueprintSpellbook, int>();
+            var calculatedResults = GetOriginalCasterLevel(unit);
+            var actual = unit.m_Spellbooks;
+            foreach (var spellbookTypePair in calculatedResults) {
+                actual.TryGetValue(spellbookTypePair.Key, out var actualSpellbook);
+                if (actualSpellbook != null) {
+                    int bonus = actualSpellbook.CasterLevel - spellbookTypePair.Value;
+                    resultsDictionary.Add(spellbookTypePair.Key, bonus);
+                }
+            }
+            UnitBonusSpellLevels.Add(unit, resultsDictionary);
+        }
+
+        private static int GetPrestigeCasterLevelStart(BlueprintProgression progression) {
+            foreach (var level in progression.LevelEntries) {
+                if (level.Features.OfType<BlueprintFeatureSelection>().SelectMany(feature => feature.AllFeatures.OfType<BlueprintFeatureReplaceSpellbook>()).Any()) {
+                    return level.Level;
+                }
+            }
+            return 1;
+        }
+
+        public static void RemoveSpellsOfLevel(Spellbook spellbook, int level) {
+            var spells = spellbook.GetKnownSpells(level);
+            spells.ForEach(x => spellbook.RemoveSpell(x.Blueprint));
+        }
+
+        public static void LowerCasterLevel(Spellbook spellbook) {
+            int oldMaxSpellLevel = spellbook.MaxSpellLevel;
+            spellbook.m_BaseLevelInternal--;
+            int newMaxSpellLevel = spellbook.MaxSpellLevel;
+            if (newMaxSpellLevel < oldMaxSpellLevel) {
+                RemoveSpellsOfLevel(spellbook, oldMaxSpellLevel);
+            }
+        }
+
+        public static void AddCasterLevel(Spellbook spellbook) {
+            int oldMaxSpellLevel = spellbook.MaxSpellLevel;
+            spellbook.m_BaseLevelInternal++;
+            int newMaxSpellLevel = spellbook.MaxSpellLevel;
+            if (newMaxSpellLevel > oldMaxSpellLevel) {
+                spellbook.LearnSpellsOnRaiseLevel(oldMaxSpellLevel, newMaxSpellLevel, false);
+            }
+        }
+    }
+}

--- a/ToyBox/classes/MainUI/PartyEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor.cs
@@ -15,6 +15,7 @@ using Kingmaker.Utility;
 using ToyBox.Multiclass;
 using Alignment = Kingmaker.Enums.Alignment;
 using ModKit;
+using ToyBox.classes.Infrastructure;
 
 namespace ToyBox {
     public class PartyEditor {
@@ -111,6 +112,10 @@ namespace ToyBox {
             else {
                 UI.Space(170);
             }
+#if DEBUG
+            UI.ActionButton("Log Caster Info", () => CasterHelpers.GetOriginalCasterLevel(ch.Descriptor),
+                UI.AutoWidth());
+#endif
         }
         public static void OnGUI() {
             var player = Game.Instance.Player;
@@ -450,8 +455,12 @@ namespace ToyBox {
                                     },
                                     UI.AutoWidth()
                                 );
+                                UI.Space(20);
+                                if (casterLevel > 0) {
+                                    UI.ActionButton("-1 CL", () => CasterHelpers.LowerCasterLevel(spellbook), UI.AutoWidth());
+                                }
                                 if (casterLevel < 20) {
-                                    UI.ActionButton("+1 Caster Level", () => spellbook.AddBaseLevel());
+                                    UI.ActionButton("+1 CL", () => CasterHelpers.AddCasterLevel(spellbook), UI.AutoWidth());
                                 }
                             }
                             FactsEditor.OnGUI(ch, spellbook, selectedSpellbookLevel);


### PR DESCRIPTION
Added the ability to calculate real caster level so we can ensure learning correct amount of spells on next level up for casters who need that, but haven't implemented it yet.