### PR TITLE
Buff multiplier now works on temporary weapon enhancments

### DIFF
--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
@@ -23,6 +23,8 @@ using Kingmaker.Globalmap.View;
 using Kingmaker.Settings;
 using Kingmaker.Settings.Difficulty;
 using ModKit;
+using Kingmaker.Blueprints.Items.Ecnchantments;
+using Kingmaker.Utility;
 
 namespace ToyBox.BagOfPatches {
     static class Multipliers {
@@ -164,6 +166,26 @@ namespace ToyBox.BagOfPatches {
                 }
 
                 //Main.Debug("Initiator: " + parentContext.MaybeCaster.CharacterName + "\nBlueprintBuff: " + blueprint.Name + "\nDuration: " + duration.ToString());
+            }
+        }
+
+        [HarmonyPatch(typeof(ItemEntity), "AddEnchantment", new Type[] {
+            typeof(BlueprintItemEnchantment),
+            typeof(MechanicsContext),
+            typeof(Rounds?)
+            })]
+        public static class ItemEntity_AddEnchantment_Patch {
+            public static void Prefix(BlueprintBuff blueprint, MechanicsContext parentContext, ref Rounds? duration) {
+                try {
+                    if (!parentContext?.MaybeCaster?.IsPlayersEnemy ?? false) {
+                        if (duration != null) {
+                            duration = new Rounds((int)(duration.Value.Value * settings.buffDurationMultiplierValue));
+                        }
+                    }
+                }
+                catch (Exception e) {
+                    modLogger.Log(e.ToString());
+                }
             }
         }
 


### PR DESCRIPTION
Adds patch to item enhancement to extend duration of temporary enhancements by a function of the buff multiplier. This means that things like divine weapon bond can now be properly extended by toybox.