### PR TITLE
Changed NewtonSoft dependency to use the InGame dll instead of latest…

### DIFF
--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -43,9 +43,6 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="Aze.Publicise.MSBuild.Task" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
-    </PackageReference>
     <Reference Include="0Harmony">
       <HintPath>$(WrathPath)\Wrath_Data\Managed\UnityModManager\0Harmony.dll</HintPath>
       <Private>False</Private>
@@ -60,6 +57,10 @@
     </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(WrathPath)\Wrath_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Owlcat.Runtime.Core">
       <HintPath>$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.Core.dll</HintPath>
       <Private>False</Private>
@@ -226,7 +227,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" info_1json__JsonSchema="https://json.schemastore.org/global.json" />
+      <UserProperties info_1json__JsonSchema="https://json.schemastore.org/global.json" config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>


### PR DESCRIPTION
Some of the ingame functions rely on NewtonSoft.Json version 8.0.0 that is actually packaged with the game.

ToyBox currently uses 13.0.1 which causes conflicts when trying to reference some ingame function that rely on the older NewtonSoft.Json version such as:

```
IContractResolver contractResolver = DefaultJsonSettings.DefaultSettings.ContractResolver;
```

This PR fixes the issue by using the ingame packaged NewtonSoft.Json dll instead.
Have done some basic functionality tests to see nothing broke. But might want to do further tests to see if any behavior is changed.