### PR TITLE
Fixed, improved Respec Feature

### DIFF
--- a/ToyBox/README.txt
+++ b/ToyBox/README.txt
@@ -11,6 +11,8 @@ Now with 260+ Cheats, Tweaks and Quality of Life Improvements
     Search 'n Pick: 75 ways to view, add, remove blueprints plus a fun global teleportation feature
     Quest Resolution: 1
 
+Ver 1.3.8
+    (Vikash) Fixed Respec Code, Can now Respec companions even if they are not in party.
 Ver 1.3.7
     You can now add key binds to cheat buttons like "Rest All", "Full Bufs", "Reroll Perception", etc 
     HotKeys now recognize shift, alt, ctrl, alt and command key combos

--- a/ToyBox/classes/MainUI/PartyEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor.cs
@@ -105,9 +105,9 @@ namespace ToyBox {
             else {
                 UI.Space(178);
             }
-            if (player.Party.Contains(ch)) {
+            if (RespecHelper.GetRespecableUnits().Contains(ch)) {
                 respecableCount++;
-                UI.ActionButton("Respec", () => { Actions.ToggleModWindow(); UnitHelper.Respec(ch); }, UI.Width(150));
+                UI.ActionButton("Respec", () => { Actions.ToggleModWindow(); RespecHelper.Respec(ch); }, UI.Width(150));
             }
             else {
                 UI.Space(170);
@@ -483,6 +483,7 @@ namespace ToyBox {
             UI.Space(25);
             if (respecableCount > 0) {
                 UI.Label($"{respecableCount} characters".yellow().bold() + " can be respecced. Pressing Respec will close the mod window and take you to character level up".orange());
+                UI.Label("WARNING".yellow().bold() + " The Respec UI is ".orange() + "Non Interruptable".yellow().bold() + " please save before using".orange());
                 UI.Label("WARNING".yellow().bold() + " this feature is ".orange() + "EXPERIMENTAL".yellow().bold() + " and uses unreleased and likely buggy code.".orange());
                 UI.Label("BACK UP".yellow().bold() + " before playing with this feature.You will lose your mythic ranks but you can restore them in this Party Editor.".orange());
 

--- a/ToyBox/classes/MainUI/RespecHelper.cs
+++ b/ToyBox/classes/MainUI/RespecHelper.cs
@@ -1,0 +1,47 @@
+﻿using Kingmaker;
+using Kingmaker.EntitySystem.Entities;
+using Kingmaker.Designers.EventConditionActionSystem.Actions;
+using Kingmaker.PubSubSystem;
+using Kingmaker.UnitLogic.Parts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ToyBox {
+    class RespecHelper {
+
+        public static List<UnitEntityData> GetRespecableUnits() {
+            Player player = Game.Instance.Player;
+            var enumerable = player.AllCrossSceneUnits.Where(delegate (UnitEntityData u) {
+                UnitPartCompanion unitPartCompanion = u.Get<UnitPartCompanion>();
+                if (unitPartCompanion == null || unitPartCompanion.State != CompanionState.InParty) {
+                    UnitPartCompanion unitPartCompanion2 = u.Get<UnitPartCompanion>();
+                    if (unitPartCompanion2 == null) {
+                        return false;
+                    }
+
+                    return unitPartCompanion2.State == CompanionState.Remote;
+                }
+
+                return true;
+            });
+            List<UnitEntityData> respecUnits = (from ch in enumerable
+                                                where RespecCompanion.CanRespec(ch)
+                                                select ch).ToList();
+            return respecUnits;
+        }
+
+        public static void Respec (UnitEntityData unit, Action successCallback = null) {
+            Main.Log("Initiating Respec");
+            EventBus.RaiseEvent(delegate (IRespecInitiateUIHandler h) {
+                h.HandleRespecInitiate(unit, FinishRespec);
+            });
+
+        }
+
+        private static void FinishRespec() {
+            Main.Log("Finishing Respec");
+            // Maybe Apply Rest Without Advancing Time ?
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the Respec functionality to use the new Respec UI from the game.
It also allows you to Respec remote companions.

Some notes:
Added warning that the new Respec UI seems to be non interruptible. So users are advised to save before using this feature.