### PR TITLE
Better handling of Legendary Heroes (or fake ones)

### DIFF
--- a/ToyBox/README.txt
+++ b/ToyBox/README.txt
@@ -20,6 +20,7 @@ Ver 1.3.8
     New categories for collating items by rarity, cost, enchant value
     Search 'n Pick now defaults to searching descriptions. Untick the checkbox to disable this
     (Vikash) Fixed Respec Code, Can now Respec companions even if they are not in party.
+    (ArcaneTrixter) Added support for Legendary Heroes throughout Toybox, made fake legendary flag per character.
 Ver 1.3.7
     You can now add key binds to cheat buttons like "Rest All", "Full Bufs", "Reroll Perception", etc 
     HotKeys now recognize shift, alt, ctrl, alt and command key combos

--- a/ToyBox/classes/MainUI/Actions.cs
+++ b/ToyBox/classes/MainUI/Actions.cs
@@ -170,12 +170,11 @@ namespace ToyBox {
             //            ch.Descriptor.Progression.RemoveMythicLevel
         }
         public static void resetClassLevel(this UnitEntityData ch) {
-            // TODO - this doesn't seem to work in BoT either...
-            int level = 21;
+            int level = ch.Descriptor.Progression.MaxCharacterLevel;
             int xp = ch.Descriptor.Progression.Experience;
-            BlueprintStatProgression xpTable = BlueprintRoot.Instance.Progression.XPTable;
+            BlueprintStatProgression xpTable = ch.Descriptor.Progression.ExperienceTable;
 
-            for (int i = 20; i >= 1; i--) {
+            for (int i = ch.Descriptor.Progression.MaxCharacterLevel; i >= 1; i--) {
                 int xpBonus = xpTable.GetBonus(i);
 
                 Main.Log(i + ": " + xpBonus + " | " + xp);

--- a/ToyBox/classes/MainUI/LevelUp.cs
+++ b/ToyBox/classes/MainUI/LevelUp.cs
@@ -63,7 +63,6 @@ namespace ToyBox {
                 () => UI.Toggle("Ignore Required Stat Values", ref settings.toggleIgnorePrerequisiteStatValue, 0),
                 () => UI.Toggle("Ignore Alignment When Choosing A Class", ref settings.toggleIgnoreAlignmentWhenChoosingClass, 0),
                 () => UI.Toggle("Skip Spell Selection", ref settings.toggleSkipSpellSelection, 0),
-                () => UI.Toggle("Always Use Legendary Hero Leveling", ref settings.toggleLegendaryLeveling, 0),
 #if DEBUG
                     () => UI.Toggle("Lock Character Level", ref settings.toggleLockCharacterLevel, 0),
                 //                    () => UI.Toggle("Ignore Alignment Restrictions", ref settings.toggleIgnoreAlignmentRestriction, 0),

--- a/ToyBox/classes/MainUI/PartyEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor.cs
@@ -156,7 +156,7 @@ namespace ToyBox {
                 var classData = ch.Progression.Classes;
                 // TODO - understand the difference between ch.Progression and ch.Descriptor.Progression
                 UnitProgressionData progression = ch.Descriptor.Progression;
-                BlueprintStatProgression xpTable = BlueprintRoot.Instance.Progression.XPTable;
+                BlueprintStatProgression xpTable = progression.ExperienceTable;
                 int level = progression.CharacterLevel;
                 int mythicLevel = progression.MythicExperience;
                 var spellbooks = ch.Spellbooks;
@@ -173,12 +173,12 @@ namespace ToyBox {
                     UI.Label("lvl".green() + $": {level}", UI.Width(75));
                     // Level up code adapted from Bag of Tricks https://www.nexusmods.com/pathfinderkingmaker/mods/2
                     if (player.AllCharacters.Contains(ch)) {
-                        if (progression.Experience < xpTable.GetBonus(level + 1) && level < 20) {
+                        if (progression.Experience < xpTable.GetBonus(level + 1) && level < xpTable.Bonuses.Length) {
                             UI.ActionButton("+1", () => {
                                 progression.AdvanceExperienceTo(xpTable.GetBonus(level + 1), true);
                             }, UI.Width(70));
                         }
-                        else if (progression.Experience >= xpTable.GetBonus(level + 1) && level < 20) {
+                        else if (progression.Experience >= xpTable.GetBonus(level + 1) && level < xpTable.Bonuses.Length) {
                             UI.Label("LvUp".cyan().italic(), UI.Width(70));
                         }
                         else { UI.Space(74); }
@@ -280,7 +280,7 @@ namespace ToyBox {
                             UI.ActionButton("<", () => prog.CharacterLevel = Math.Max(0, prog.CharacterLevel - 1), UI.AutoWidth());
                             UI.Space(25);
                             UI.Label("level".green() + $": {prog.CharacterLevel}", UI.Width(100f));
-                            UI.ActionButton(">", () => prog.CharacterLevel = Math.Min(20, prog.CharacterLevel + 1), UI.AutoWidth());
+                            UI.ActionButton(">", () => prog.CharacterLevel = Math.Min(prog.MaxCharacterLevel, prog.CharacterLevel + 1), UI.AutoWidth());
                             UI.Space(25);
                             UI.ActionButton("Reset", () => ch.resetClassLevel(), UI.Width(125));
                             UI.Space(23);
@@ -296,11 +296,30 @@ namespace ToyBox {
                             UI.Label($"{prog.Experience}", UI.Width(150f));
                             UI.Space(36);
                             UI.ActionButton("Set", () => {
-                                int newXP = BlueprintRoot.Instance.Progression.XPTable.GetBonus(Mathf.RoundToInt(prog.CharacterLevel));
+                                int newXP = prog.ExperienceTable.GetBonus(Mathf.RoundToInt(prog.CharacterLevel));
                                 prog.Experience = newXP;
                             }, UI.Width(125));
                             UI.Space(23);
                             UI.Label("This sets your experience to match the current value of character level.".green());
+                        }
+
+                        using (UI.HorizontalScope()) {
+                            UI.Space(100);
+                            UI.ActionToggle("Levels like a Legendary Hero",
+                                () => {
+                                    bool hasValue = settings.charIsLegendaryHero.TryGetValue(ch.HashKey(), out bool isLegendaryHero);
+                                    return hasValue && isLegendaryHero;
+                                },
+                                (val) => {
+                                    if (settings.charIsLegendaryHero.ContainsKey(ch.HashKey())) {
+                                        settings.charIsLegendaryHero[ch.HashKey()] = val;
+                                    } else {
+                                        settings.charIsLegendaryHero.Add(ch.HashKey(), val);
+                                    }
+                                },
+                                0f,
+                                UI.AutoWidth()
+                            );
                         }
                         UI.Div(100, 25);
                         using (UI.HorizontalScope()) {

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -94,7 +94,6 @@ namespace ToyBox {
         public bool toggleSkipSpellSelection = false;
         public bool toggleNextWhenNoAvailableFeatSelections = true;
         public bool toggleOptionalFeatSelection = false;
-        public bool toggleLegendaryLeveling = false;
 
         // Multipliers
         public int encumberanceMultiplier = 1;
@@ -187,6 +186,9 @@ namespace ToyBox {
 
         // This is the set of classes that each char has leveled up under multi-class.  They will be excluded from char level calculations
         public SerializableDictionary<string, HashSet<string>> excludeClassesFromCharLevelSets = new SerializableDictionary<string, HashSet<string>>();
+
+        // Dictionary of Name/IsLegendaryHero for configuration per party member
+        public SerializableDictionary<string, bool> charIsLegendaryHero = new SerializableDictionary<string, bool>();
 
         public Multiclass.ProgressionPolicy multiclassHitPointPolicy = 0;
         public Multiclass.ProgressionPolicy multiclassSavingThrowPolicy = 0;

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUp.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUp.cs
@@ -8,7 +8,6 @@ using Kingmaker.Blueprints.Classes;
 using Kingmaker.Blueprints.Classes.Prerequisites;
 using Kingmaker.Blueprints.Classes.Selection;
 using Kingmaker.Blueprints.Facts;
-using Kingmaker.Blueprints.Root;
 using Kingmaker.EntitySystem.Stats;
 using Kingmaker.UnitLogic;
 using Kingmaker.UnitLogic.Class.LevelUp;
@@ -19,6 +18,9 @@ using System.Linq;
 using UnityModManager = UnityModManagerNet.UnityModManager;
 using Kingmaker.UI.MVVM._VM.CharGen.Phases.Skills;
 using Kingmaker.UI.MVVM._VM.CharGen.Phases.FeatureSelector;
+using Kingmaker.UI.MVVM._VM.ServiceWindows.CharacterInfo.Sections.LevelClassScores.Experience;
+using Kingmaker.UI.ServiceWindow;
+using UnityEngine;
 
 namespace ToyBox.BagOfPatches {
     static class LevelUp {
@@ -38,27 +40,43 @@ namespace ToyBox.BagOfPatches {
         [HarmonyPatch(typeof(UnitProgressionData))]
         static class UnitProgressionData_LegendaryHero_Patch {
             [HarmonyPatch("ExperienceTable", MethodType.Getter)]
-            private static void Postfix(ref BlueprintStatProgression __result) {
-                __result = !settings.toggleLegendaryLeveling
+            private static void Postfix(ref BlueprintStatProgression __result, UnitProgressionData __instance) {
+                settings.charIsLegendaryHero.TryGetValue(__instance.Owner.HashKey(), out bool isFakeLegendaryHero);
+                bool legendaryHero = __instance.Owner.State.Features.LegendaryHero || isFakeLegendaryHero;
+                __result = !legendaryHero
                         ? Game.Instance.BlueprintRoot.Progression.XPTable
                         : Game.Instance.BlueprintRoot.Progression.LegendXPTable.Or(null)
                           ?? Game.Instance.BlueprintRoot.Progression.XPTable;
             }
 
             [HarmonyPatch("MaxCharacterLevel", MethodType.Getter)]
-            private static void Postfix(ref int __result) {
-                if (settings.toggleLegendaryLeveling) {
+            private static void Postfix(ref int __result, UnitProgressionData __instance) {
+                settings.charIsLegendaryHero.TryGetValue(__instance.Owner.HashKey(), out bool isFakeLegendaryHero);
+                bool isLegendaryHero = __instance.Owner.State.Features.LegendaryHero || isFakeLegendaryHero;
+                if (isLegendaryHero) {
                     __result = 40;
                 }
             }
         }
 
-        [HarmonyPatch(typeof(ProgressionRoot), "XPTable", MethodType.Getter)]
-        static class ProgressionRoot_FixExperienceBar_Patch {
-            public static void Postfix(ref BlueprintStatProgression __result, ProgressionRoot __instance) {
-                if (settings.toggleLegendaryLeveling) {
-                    __result = __instance.LegendXPTable;
-                }
+        [HarmonyPatch(typeof(CharSheetCommonLevel), "Initialize")]
+        static class CharSheetCommonLevel_FixExperienceBar_Patch {
+            public static void Postfix(UnitProgressionData data, ref CharSheetCommonLevel __instance) {
+                __instance.Level.text = "Level " + data.CharacterLevel;
+                int nextLevel = data.ExperienceTable.Bonuses[data.CharacterLevel + 1];
+                int currentLevel = data.ExperienceTable.Bonuses[data.CharacterLevel];
+                int experience = data.Experience;
+                __instance.Exp.text = $"{experience as object}/{nextLevel as object}";
+                __instance.Bar.value = (float)(experience - currentLevel) / (float)(nextLevel - currentLevel);
+            }
+        }
+
+        [HarmonyPatch(typeof(CharInfoExperienceVM), "RefreshData")]
+        static class CharInfoExperienceVM_FixExperienceBar_Patch {
+            public static void Postfix(ref CharInfoExperienceVM __instance) {
+                var unit = __instance.Unit.Value;
+                __instance.NextLevelExp = unit.Progression.ExperienceTable.Bonuses[Mathf.Min(unit.Progression.CharacterLevel + 1, unit.Progression.ExperienceTable.Bonuses.Length - 1)];
+                __instance.CurrentLevelExp = unit.Progression.ExperienceTable.Bonuses.ElementAtOrDefault(unit.Progression.CharacterLevel);
             }
         }
 


### PR DESCRIPTION
Moved Fake Legendary Hero flag to be per character, made toybox aware of the different experience tables and max levels for handling level calculations for gestalt + others.