### PR TITLE
added 4 new tweaks

### DIFF
--- a/ToyBox/README.txt
+++ b/ToyBox/README.txt
@@ -5,7 +5,7 @@ Toy Box is a cute and playful mod with 240+ cheats, tweaks and quality of life i
 # Detailed Description
 
 Now with 260+ Cheats, Tweaks and Quality of Life Improvements
-    Tweaks: 84 (or 125 depending on how you count)
+    Tweaks: 88 (or 129 depending on how you count)
     Level Up & Multiclass: 34
     Party Editor: 67    
     Search 'n Pick: 75 ways to view, add, remove blueprints plus a fun global teleportation feature
@@ -20,6 +20,10 @@ Ver 1.3.8
     New categories for collating items by cost and enchant value
     Search 'n Pick now defaults to searching descriptions. Untick the checkbox to disable this
     (Vikash) Fixed Respec Code, Can now Respec companions even if they are not in party.
+    (Truinto) Added tweak: Auto Start Rage When Entering Combat
+    (Truinto) Added tweak: Mass Loot Shows Everything When Leaving Map
+    (Truinto) Added tweak: Equipment No Weight
+    (Truinto) Added tweak: Allow Item Use From Inventory During Combat
 Ver 1.3.7
     You can now add key binds to cheat buttons like "Rest All", "Full Bufs", "Reroll Perception", etc 
     HotKeys now recognize shift, alt, ctrl, alt and command key combos

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -172,6 +172,9 @@ namespace ToyBox {
                 () => UI.Toggle("Make Tutorials Not Appear If Disabled In Settings", ref settings.toggleForceTutorialsToHonorSettings),
                 () => UI.Toggle("Refill consumables in belt slots if in inventory", ref settings.togglAutoEquipConsumables),
                 () => UI.Toggle("Instant change party members", ref settings.toggleInstantChangeParty),
+                () => UI.Toggle("Mass Loot Shows Everything When Leaving Map (some items might be invisible until looted)", ref settings.toggleMassLootEverything),
+                () => UI.Toggle("Equipment No Weight (turning this off requires you to reload for it to take full effect)", ref settings.toggleEquipmentNoWeight),
+                () => UI.Toggle("Allow Item Use From Inventory During Combat", ref settings.toggleUseItemsDuringCombat),
                 () => { }
                 );
             UI.Div(153, 25);
@@ -190,6 +193,7 @@ namespace ToyBox {
                 () => UI.Toggle("Witch/Shaman: Cackling/Shanting Extends Hexes By 10 Min (Out Of Combat)", ref settings.toggleExtendHexes),
                 () => UI.Toggle("Allow Simultaneous Activatable Abilities (Like Judgements)", ref settings.toggleAllowAllActivatable),
                 () => UI.Toggle("Kineticist: Allow Gather Power Without Hands", ref settings.toggleKineticistGatherPower),
+                () => UI.Toggle("Barbarian: Auto Start Rage When Entering Combat", ref settings.toggleEnterCombatAutoRage),
                 () => UI.Toggle("Magus: Always Allow Spell Combat", ref settings.toggleAlwaysAllowSpellCombat),
                 () => { }
                 );

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -50,6 +50,10 @@ namespace ToyBox {
         public bool toggleKineticistGatherPower = false;
         public bool toggleAlwaysAllowSpellCombat = false;
         public bool toggleInstantPartyChange = false;
+        public bool toggleEnterCombatAutoRage = false;
+        public bool toggleMassLootEverything = false;
+        public bool toggleEquipmentNoWeight = false;
+        public bool toggleUseItemsDuringCombat = false;
         public bool toggleTeleportKeysEnabled = false;
 
         // Loot Coloring & Filtering

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ It was created in the spirit of Bag of Tricks & Cheat Menu but with a little dif
   - Items
   - etc.
 
+Download: [nexusmods.com](https://www.nexusmods.com/pathfinderwrathoftherighteous/mods/8)
+
 # How to contribute
 
 - on the [main repository page](https://github.com/cabarius/ToyBox) click on "fork" in the upper-right corner


### PR DESCRIPTION
Added tweak: Auto Start Rage When Entering Combat
Added tweak: Mass Loot Shows Everything When Leaving Map
Added tweak: Equipment No Weight
Added tweak: Allow Item Use From Inventory During Combat

this closes #262

Remarks:
- Mass Loot Everything still hides items from living enemies, although the Loot All button still loots them. Still really useful as to not miss relic parts.
- Disabling Equipment No Weight only seems to work for the shared inventory after saving and reloading.