### PR TITLE
Caster level improvements

### DIFF
--- a/ToyBox/README.txt
+++ b/ToyBox/README.txt
@@ -26,6 +26,7 @@ Ver 1.3.10
     (Delth) hopefully fixed gestalt skillpoint calculations
     (ArcaneTrixter) Added toggle to remove Level 20 Caster Level cap.
     (ArcaneTrixter) Added ability to merge standalone mythics into any spellbook. Spell slots and spells per day are still based on the original type, e.g. Magus gets 6th level spells and below.
+    (ArcaneTrixter) Added Add All button to spellbooks when browsing new spells. It works with Search All Spellbooks and respects current search results.
 Ver 1.3.9
     Made Alignment section in Bag of Tricks
         Fixing alignment shifts for neutral good and similar alignments

--- a/ToyBox/README.txt
+++ b/ToyBox/README.txt
@@ -24,6 +24,7 @@ Ver 1.3.10
     (ArcaneTrixter) Reorganized stat section of party editor to not just be the random enum order.
     (ArcaneTrixter) Allowed multiple judgements to be active at once.
     (Delth) hopefully fixed gestalt skillpoint calculations
+    (ArcaneTrixter) Added toggle to remove Level 20 Caster Level cap.
 Ver 1.3.9
     Made Alignment section in Bag of Tricks
         Fixing alignment shifts for neutral good and similar alignments

--- a/ToyBox/README.txt
+++ b/ToyBox/README.txt
@@ -25,6 +25,7 @@ Ver 1.3.10
     (ArcaneTrixter) Allowed multiple judgements to be active at once.
     (Delth) hopefully fixed gestalt skillpoint calculations
     (ArcaneTrixter) Added toggle to remove Level 20 Caster Level cap.
+    (ArcaneTrixter) Added ability to merge standalone mythics into any spellbook. Spell slots and spells per day are still based on the original type, e.g. Magus gets 6th level spells and below.
 Ver 1.3.9
     Made Alignment section in Bag of Tricks
         Fixing alignment shifts for neutral good and similar alignments

--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -177,7 +177,7 @@
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\LevelUp.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Limits\Infinites.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Limits\Metamagic.cs" />
-    <Compile Include="classes\MonkeyPatchin\BagOfPatches\Limits\Unrestsricted.cs" />
+    <Compile Include="classes\MonkeyPatchin\BagOfPatches\Limits\Unrestricted.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Loot.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Misc.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Movement.cs" />
@@ -234,7 +234,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" info_1json__JsonSchema="https://json.schemastore.org/global.json" />
+      <UserProperties info_1json__JsonSchema="https://json.schemastore.org/global.json" config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/ToyBox/classes/Infrastructure/CasterHelpers.cs
+++ b/ToyBox/classes/Infrastructure/CasterHelpers.cs
@@ -4,6 +4,8 @@ using Kingmaker.Blueprints.Classes.Selection;
 using Kingmaker.Blueprints.Classes.Spells;
 using Kingmaker.Blueprints.Root;
 using Kingmaker.UnitLogic;
+using Kingmaker.UnitLogic.Abilities;
+using Kingmaker.UnitLogic.Abilities.Blueprints;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -97,6 +99,37 @@ namespace ToyBox.classes.Infrastructure {
             int newMaxSpellLevel = spellbook.MaxSpellLevel;
             if (newMaxSpellLevel > oldMaxSpellLevel) {
                 spellbook.LearnSpellsOnRaiseLevel(oldMaxSpellLevel, newMaxSpellLevel, false);
+            }
+        }
+
+        public static void AddAllSpellsOfSelectedLevel(Spellbook spellbook, int level) {
+            List<BlueprintAbility> toLearn;
+            if (Main.settings.showFromAllSpellbooks) {
+                var normal = BlueprintExensions.GetBlueprints<BlueprintSpellbook>()
+                    .Where(x => ((BlueprintSpellbook)x).SpellList != null)
+                    .SelectMany(x => ((BlueprintSpellbook)x).SpellList.GetSpells(level));
+                var mythic = BlueprintExensions.GetBlueprints<BlueprintSpellbook>()
+                    .Where(x => ((BlueprintSpellbook)x).MythicSpellList != null)
+                    .SelectMany(x => ((BlueprintSpellbook)x).MythicSpellList.GetSpells(level));
+                toLearn = normal.Concat(mythic).Distinct().ToList();
+            }
+            else {
+                toLearn = spellbook.Blueprint.SpellList.GetSpells(level);
+            }
+
+            toLearn.ForEach(x => spellbook.AddKnown(level, x));
+        }
+
+        public static void HandleAddAllSpellsOnPartyEditor(UnitDescriptor unit, List<BlueprintAbility> abilities) {
+            if (!PartyEditor.SelectedSpellbook.TryGetValue(unit.HashKey(), out var selectedSpellbook)) {
+                return;
+            }
+
+            if (abilities != null) {
+                abilities.ForEach(x => selectedSpellbook.AddKnown(PartyEditor.selectedSpellbookLevel, x));
+            }
+            else {
+                AddAllSpellsOfSelectedLevel(selectedSpellbook, PartyEditor.selectedSpellbookLevel);
             }
         }
 

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -178,6 +178,7 @@ namespace ToyBox {
                 () => UI.ToggleCallback("Equipment No Weight", ref settings.toggleEquipmentNoWeight, BagOfPatches.Tweaks.NoWeight_Patch1.Refresh),
                 () => UI.Toggle("Allow Item Use From Inventory During Combat", ref settings.toggleUseItemsDuringCombat),
                 () => UI.Toggle("Ignore Alignment Requirements for Abilities", ref settings.toggleIgnoreAbilityAlignmentRestriction),
+                () => UI.Toggle("Remove Level 20 Caster Level Cap", ref settings.toggleUncappedCasterLevel),
                 () => { }
                 );
             UI.Div(153, 25);

--- a/ToyBox/classes/MainUI/FactsEditor.cs
+++ b/ToyBox/classes/MainUI/FactsEditor.cs
@@ -14,6 +14,7 @@ using Kingmaker.UnitLogic.Buffs;
 using Kingmaker.UnitLogic.Buffs.Blueprints;
 using ModKit;
 using ModKit.Utility;
+using ToyBox.classes.Infrastructure;
 
 namespace ToyBox {
     public class FactsEditor {
@@ -89,9 +90,10 @@ namespace ToyBox {
                 UI.Space(100);
                 UI.ActionButton("Search", () => { searchChanged = true; }, UI.AutoWidth());
                 UI.Space(25);
-                if (showAll) {
+                if (showAll && typeof(T) == typeof(AbilityData)) { // This is obviously tech debt, but I don't want to deal with Search All Spellbooks/Add All being on the facts editor as it is now
                     UI.Toggle("Search All Spellbooks", ref settings.showFromAllSpellbooks);
                     UI.Space(25);
+                    UI.ActionButton("Add All", () => { CasterHelpers.HandleAddAllSpellsOnPartyEditor(unit.Descriptor, filteredBPs.Cast<BlueprintAbility>().ToList());}, UI.AutoWidth());
                 }
                 if (matchCount > 0 && searchText.Length > 0) {
                     String matchesText = "Matches: ".green().bold() + $"{matchCount}".orange().bold();

--- a/ToyBox/classes/MainUI/PartyEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor.cs
@@ -501,7 +501,7 @@ namespace ToyBox {
                                 if (casterLevel > 0) {
                                     UI.ActionButton("-1 CL", () => CasterHelpers.LowerCasterLevel(spellbook), UI.AutoWidth());
                                 }
-                                if (casterLevel < 20) {
+                                if (casterLevel < 40) {
                                     UI.ActionButton("+1 CL", () => CasterHelpers.AddCasterLevel(spellbook), UI.AutoWidth());
                                 }
                             }

--- a/ToyBox/classes/MainUI/PartyEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor.cs
@@ -6,15 +6,14 @@ using System.Linq;
 using Kingmaker;
 using Kingmaker.Blueprints.Classes;
 using Kingmaker.Blueprints.Classes.Spells;
-using Kingmaker.Blueprints.Root;
 using Kingmaker.Designers;
 using Kingmaker.EntitySystem.Entities;
 using Kingmaker.EntitySystem.Stats;
 using Kingmaker.UnitLogic;
-using Kingmaker.Utility;
 using ToyBox.Multiclass;
 using Alignment = Kingmaker.Enums.Alignment;
 using ModKit;
+using ModKit.Utility;
 using ToyBox.classes.Infrastructure;
 
 namespace ToyBox {
@@ -503,6 +502,12 @@ namespace ToyBox {
                                 }
                                 if (casterLevel < 40) {
                                     UI.ActionButton("+1 CL", () => CasterHelpers.AddCasterLevel(spellbook), UI.AutoWidth());
+                                }
+
+                                UI.Space(20);
+                                if (ch.Spellbooks.Where(x => x.IsStandaloneMythic).Any(y => y.Blueprint.CharacterClass == ch.Progression.GetMythicToMerge().CharacterClass)) {
+                                    UI.ActionButton("Merge Mythic Levels and Selected Spellbook", () => CasterHelpers.ForceSpellbookMerge(spellbook), UI.AutoWidth());
+                                    UI.Label("Warning: This is irreversible. Please save before continuing!".Orange());
                                 }
                             }
                             SelectedSpellbook[ch.HashKey()] = spellbook;

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -3,7 +3,6 @@ using ModKit.Utility;
 using System.Collections.Generic;
 using UnityModManagerNet;
 using UnityEngine;
-using Kingmaker.UnitLogic.Alignments;
 
 namespace ToyBox {
     public class Settings : UnityModManager.ModSettings {
@@ -111,6 +110,7 @@ namespace ToyBox {
         public bool toggleNextWhenNoAvailableFeatSelections = true;
         public bool toggleOptionalFeatSelection = false;
         public bool toggleUniversalSpellbookd = false;
+        public bool toggleUncappedCasterLevel = false;
 
         // Multipliers
         public int encumberanceMultiplier = 1;

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Limits/Unrestricted.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Limits/Unrestricted.cs
@@ -3,15 +3,11 @@ using HarmonyLib;
 using Kingmaker;
 using Kingmaker.Blueprints.Items.Components;
 using Kingmaker.Blueprints.Items.Equipment;
-//using Kingmaker.Controllers.GlobalMap;
 using Kingmaker.DialogSystem.Blueprints;
 using Kingmaker.Items;
 using Kingmaker.Kingdom.Settlements;
-//using Kingmaker.UI._ConsoleUI.Models;
-//using Kingmaker.UI.RestCamp;
 using Kingmaker.UnitLogic;
 using System;
-//using Kingmaker.UI._ConsoleUI.GroupChanger;
 using UnityModManager = UnityModManagerNet.UnityModManager;
 
 namespace ToyBox.BagOfPatches {
@@ -96,6 +92,15 @@ namespace ToyBox.BagOfPatches {
             public static void Postfix(ref bool __result) {
                 if (settings.toggleSettlementRestrictions) {
                     __result = true;
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(Spellbook), nameof(Spellbook.CasterLevel), MethodType.Getter)]
+        public static class Spellbook_CasterLevel_Patch {
+            public static void Postfix(ref int __result, Spellbook __instance) {
+                if (settings.toggleUncappedCasterLevel) {
+                    __result += __instance.m_BaseLevelInternal - __instance.BaseLevel;
                 }
             }
         }


### PR DESCRIPTION
Allows caster level greater than level 20 based on toggle (spells known as if level 20). Allows merging standalone mythic spellbooks into any caster (even half casters, caveat emptor). Adds Add All button to spellbooks for mass adding searched for (or **all**) spells of a given level.