### PR TITLE
Rework of the feat multipiler

### DIFF
--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUp.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUp.cs
@@ -404,31 +404,34 @@ namespace ToyBox.BagOfPatches {
 
         [HarmonyPatch(typeof(LevelUpHelper), "AddFeaturesFromProgression")]
         public static class MultiplyFeatPoints_LevelUpHelper_AddFeatures_Patch {
-            public static bool Prefix(
+            private static readonly BlueprintGuid[] AllowedProgressions = new BlueprintGuid[] {
+                BlueprintGuid.Parse("5b72dd2ca2cb73b49903806ee8986325") //BasicFeatsProgression
+            };
+            public static void Postfix(
                 [NotNull] LevelUpState state,
                 [NotNull] UnitDescriptor unit,
                 [NotNull] IList<BlueprintFeatureBase> features,
                 FeatureSource source,
                 int level) {
-                if (settings.featsMultiplier < 2) return true;
-                //modLogger.Log($"name: {unit.CharacterName} isMemberOrPet:{unit.IsPartyMemberOrPet()}".cyan().bold());
-                if (!unit.IsPartyOrPet()) return true;
-                modLogger.Log($"Log adding {settings.featsMultiplier}x features for {unit.CharacterName}");
-                foreach (BlueprintFeature blueprintFeature in features.OfType<BlueprintFeature>()) {
-                    for (int i = 0; i < settings.featsMultiplier; ++i) {
-                        if (blueprintFeature.MeetsPrerequisites((FeatureSelectionState)null, unit, state, true)) {
-                            if (blueprintFeature is IFeatureSelection selection && (!selection.IsSelectionProhibited(unit) || selection.IsObligatory()))
-                                state.AddSelection((FeatureSelectionState)null, source, selection, level);
-                            Kingmaker.UnitLogic.Feature feature = (Kingmaker.UnitLogic.Feature)unit.AddFact((BlueprintUnitFact)blueprintFeature);
-                            if (blueprintFeature is BlueprintProgression progression)
-                                LevelUpHelper.UpdateProgression(state, unit, progression);
-                            FeatureSource source1 = source;
-                            int level1 = level;
-                            feature.SetSource(source1, level1);
-                        }
+
+                if (settings.featsMultiplier < 2) { return; }
+                if (!unit.IsPartyOrPet()) { return; }
+                if (!AllowedProgressions.Any(allowed => source.Blueprint.AssetGuid.Equals(allowed))) { return; }
+                int multiplier = settings.featsMultiplier - 1;
+                modLogger.Log($"Log adding {settings.featsMultiplier}x feats for {unit.CharacterName}");
+                foreach (var selection in features.OfType<BlueprintFeatureSelection>().Where(s => s.GetGroup() == FeatureGroup.Feat)) {
+                    if (selection.MeetsPrerequisites(null, unit, state, true) 
+                        && (!selection.IsSelectionProhibited(unit) || selection.IsObligatory())) {
+
+                        ExecuteByMultiplier(multiplier, () => state.AddSelection(null, source, selection, level));
                     }
                 }
-                return false;
+                return;
+            }
+            private static void ExecuteByMultiplier(int multiplier, Action run = null) {
+                for (int i = 0;i < multiplier;++i) {
+                    run.Invoke();
+                }
             }
         }
     }

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUp.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUp.cs
@@ -404,6 +404,7 @@ namespace ToyBox.BagOfPatches {
 
         [HarmonyPatch(typeof(LevelUpHelper), "AddFeaturesFromProgression")]
         public static class MultiplyFeatPoints_LevelUpHelper_AddFeatures_Patch {
+            //Defines which progressions are allowed to be multipiled to prevent unexpected behavior
             private static readonly BlueprintGuid[] AllowedProgressions = new BlueprintGuid[] {
                 BlueprintGuid.Parse("5b72dd2ca2cb73b49903806ee8986325") //BasicFeatsProgression
             };
@@ -417,9 +418,14 @@ namespace ToyBox.BagOfPatches {
                 if (settings.featsMultiplier < 2) { return; }
                 if (!unit.IsPartyOrPet()) { return; }
                 if (!AllowedProgressions.Any(allowed => source.Blueprint.AssetGuid.Equals(allowed))) { return; }
-                int multiplier = settings.featsMultiplier - 1;
+                
                 modLogger.Log($"Log adding {settings.featsMultiplier}x feats for {unit.CharacterName}");
-                foreach (var selection in features.OfType<BlueprintFeatureSelection>().Where(s => s.GetGroup() == FeatureGroup.Feat)) {
+                int multiplier = settings.featsMultiplier - 1;
+                //We filter to only include feat selections of the feat group to prevent things like deities being multiplied
+                var featSelections = features
+                    .OfType<BlueprintFeatureSelection>()
+                    .Where(s => s.GetGroup() == FeatureGroup.Feat);
+                foreach (var selection in featSelections) {
                     if (selection.MeetsPrerequisites(null, unit, state, true) 
                         && (!selection.IsSelectionProhibited(unit) || selection.IsObligatory())) {
 

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
@@ -23,6 +23,8 @@ using Kingmaker.Globalmap.View;
 using Kingmaker.Settings;
 using Kingmaker.Settings.Difficulty;
 using ModKit;
+using Kingmaker.Blueprints.Items.Ecnchantments;
+using Kingmaker.Utility;
 
 namespace ToyBox.BagOfPatches {
     static class Multipliers {
@@ -164,6 +166,26 @@ namespace ToyBox.BagOfPatches {
                 }
 
                 //Main.Debug("Initiator: " + parentContext.MaybeCaster.CharacterName + "\nBlueprintBuff: " + blueprint.Name + "\nDuration: " + duration.ToString());
+            }
+        }
+
+        [HarmonyPatch(typeof(ItemEntity), "AddEnchantment", new Type[] {
+            typeof(BlueprintItemEnchantment),
+            typeof(MechanicsContext),
+            typeof(Rounds?)
+            })]
+        public static class ItemEntity_AddEnchantment_Patch {
+            public static void Prefix(BlueprintBuff blueprint, MechanicsContext parentContext, ref Rounds? duration) {
+                try {
+                    if (!parentContext?.MaybeCaster?.IsPlayersEnemy ?? false) {
+                        if (duration != null) {
+                            duration = new Rounds((int)(duration.Value.Value * settings.buffDurationMultiplierValue));
+                        }
+                    }
+                }
+                catch (Exception e) {
+                    modLogger.Log(e.ToString());
+                }
             }
         }
 


### PR DESCRIPTION
The feat multiplier is the source of several hard to track down bugs. To quote ArcaneTrixter:

1) All story companions feats/backgrounds/etc. most notably a certain wizard who unlearns how to cast spells if your multiplier is at least 8. Also this is retroactive if you ever level up in the future with the multiplier on. 
2) All mythic 'fake' companions like Skele Minion for lich or Azata summon. 
3) Required adding in "skip feat selection" because it broke level ups. 
4) Causes certain gestalt combinations to give sudden ridiculous levelups of companions or sneak attack or kinetic blast.

This re targets the multiplier into a Postfix instead of a Prefix to reduce the patch foot print, as well as adds progression whitelisting to make feature multiplication opt in by the developer instead of just multiplying everything always. As setup in this request only the base feat selections that all characters get will be multiplied, which to my mind best suits the name and description of what this setting does. This should also significantly reduce or resolve several associated bugs due to the reduction of scope on this feature.