### PR TITLE
remove dialog restrictions for mythic path as well

### DIFF
--- a/ToyBox/README.txt
+++ b/ToyBox/README.txt
@@ -13,6 +13,7 @@ Now with 300+ Cheats, Tweaks and Quality of Life Improvements
     Quest Resolution: 1
 Ver 1.3.11
     Found a grey that works for trash loot. The previous brown still looked too much like a meaningful loot color
+    (Truinto) Added Disable Dialog Restrictions (Mythic Path)
 Ver 1.3.10
     Added new top level tab: "Loot"
         Moved Loot Coloring Settings to Loot Tab

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -162,8 +162,11 @@ namespace ToyBox {
                 () => UI.Toggle("Disable Equipment Restrictions", ref settings.toggleEquipmentRestrictions, 0),
                 () => UI.Toggle("Disable Armor Max Dexterity", ref settings.toggleIgnoreMaxDexterity, 0),
 
-                () => UI.Toggle("Disable Dialog Restrictions", ref settings.toggleDialogRestrictions, 0),
-
+                () => UI.Toggle("Disable Dialog Restrictions (Alignment)", ref settings.toggleDialogRestrictions, 0),
+                () => UI.Toggle("Disable Dialog Restrictions (Mythic Path)", ref settings.toggleDialogRestrictionsMythic, 0),
+#if DEBUG
+                () => UI.Toggle("Disable Dialog Restrictions (Everything, Experimental)", ref settings.toggleDialogRestrictionsEverything, 0),
+#endif
                 () => UI.Toggle("No Friendly Fire On AOEs", ref settings.toggleNoFriendlyFireForAOE, 0),
                 () => UI.Toggle("Free Meta-Magic", ref settings.toggleMetamagicIsFree, 0),
 

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -29,6 +29,8 @@ namespace ToyBox {
         public bool togglePartyNegativeLevelImmunity = false;
         public bool togglePartyAbilityDamageImmunity = false;
         public bool toggleDialogRestrictions = false;
+        public bool toggleDialogRestrictionsMythic = false;
+        public bool toggleDialogRestrictionsEverything = false;
         public bool toggleNoFriendlyFireForAOE = false;
         public bool toggleSettlementRestrictions = false;
         public bool toggleMoveSpeedAsOne = false;

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Limits/Unrestricted.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Limits/Unrestricted.cs
@@ -68,7 +68,7 @@ namespace ToyBox.BagOfPatches {
             }
         }
 
-        [HarmonyPatch(typeof(BlueprintAnswerBase), "IsAlignmentRequirementSatisfied", MethodType.Getter)]
+        [HarmonyPatch(typeof(BlueprintAnswerBase), nameof(BlueprintAnswerBase.IsAlignmentRequirementSatisfied), MethodType.Getter)]
         public static class BlueprintAnswerBase_IsAlignmentRequirementSatisfied_Patch {
             public static void Postfix(ref bool __result) {
                 if (settings.toggleDialogRestrictions) {
@@ -77,6 +77,23 @@ namespace ToyBox.BagOfPatches {
             }
         }
 
+        [HarmonyPatch(typeof(BlueprintAnswerBase), nameof(BlueprintAnswerBase.IsMythicRequirementSatisfied), MethodType.Getter)]
+        public static class BlueprintAnswerBase_IsMythicRequirementSatisfied_Patch {
+            public static void Postfix(ref bool __result) {
+                if (settings.toggleDialogRestrictionsMythic) {
+                    __result = true;
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(BlueprintAnswer), nameof(BlueprintAnswer.CanSelect))]
+        public static class BlueprintAnswer_CanSelect_Patch {
+            public static void Postfix(ref bool __result) {
+                if (settings.toggleDialogRestrictionsEverything) {
+                    __result = true;
+                }
+            }
+        }
 
         [HarmonyPatch(typeof(BlueprintSettlementBuilding), "CheckRestrictions", new Type[] { typeof(SettlementState) })]
         public static class BlueprintSettlementBuilding_CheckRestrictions_Patch1 {


### PR DESCRIPTION
I checked it on a couple dialogs. Worked fine. I also added a debug block for patching "SelectConditions.Check" restriction, which I don't know what it does. I am yet to stumble upon a dialog that uses this.