### PR TITLE
adds an option to highlight hidden interactable objects

### DIFF
--- a/ToyBox/classes/MainUI/Actions.cs
+++ b/ToyBox/classes/MainUI/Actions.cs
@@ -352,5 +352,15 @@ namespace ToyBox {
 
             timelineManager.UpdateTimeline();
         }
+
+        // called when changing highlight settings so they take immediate effect
+        public static void UpdateHighlights(bool on) {
+            foreach (MapObjectEntityData mapObjectEntityData in Game.Instance.State.MapObjects) {
+                mapObjectEntityData.View.UpdateHighlight();
+            }
+            foreach (UnitEntityData unitEntityData in Game.Instance.State.Units) {
+                unitEntityData.View.UpdateHighlight(false);
+            }
+        }
     }
 }

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -274,6 +274,15 @@ namespace ToyBox {
                 () => UI.Toggle("Allow Item Use From Inventory During Combat", ref settings.toggleUseItemsDuringCombat),
                 () => UI.Toggle("Ignore Alignment Requirements for Abilities", ref settings.toggleIgnoreAbilityAlignmentRestriction),
                 () => UI.Toggle("Remove Level 20 Caster Level Cap", ref settings.toggleUncappedCasterLevel),
+                () => {
+                    using (UI.HorizontalScope()) {
+                        UI.ToggleCallback("Highlight Hidden Objects", ref settings.highlightHiddenObjects, Actions.UpdateHighlights);
+                        if (settings.highlightHiddenObjects) {
+                            UI.Space(100);
+                            UI.ToggleCallback("In Fog Of War ", ref settings.highlightHiddenObjectsInFog, Actions.UpdateHighlights);
+                        }
+                    }
+                },
                 () => { }
                 );
             UI.Div(153, 25);

--- a/ToyBox/classes/MainUI/Main.cs
+++ b/ToyBox/classes/MainUI/Main.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityModManagerNet;
 using HarmonyLib;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Kingmaker;
@@ -43,6 +44,8 @@ namespace ToyBox {
 
         private static Exception caughtException = null;
 
+        public static List<GameObject> Objects;
+
         private static bool Load(UnityModManager.ModEntry modEntry) {
             try {
 #if DEBUG
@@ -62,6 +65,7 @@ namespace ToyBox {
                 modEntry.OnGUI = OnGUI;
                 modEntry.OnUpdate = OnUpdate;
                 modEntry.OnSaveGUI = OnSaveGUI;
+                Objects = new List<GameObject>();
                 UI.KeyBindings.OnLoad(modEntry);
                 multiclassMod = new Multiclass.MulticlassMod();
                 HumanFriendly.EnsureFriendlyTypesContainAll();
@@ -74,6 +78,9 @@ namespace ToyBox {
         }
 #if DEBUG
         private static bool Unload(UnityModManager.ModEntry modEntry) {
+            foreach (GameObject obj in Objects) {
+                GameObject.DestroyImmediate(obj);
+            }
             HarmonyInstance.UnpatchAll(modId);
             NeedsActionInit = true;
             return true;

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -67,6 +67,8 @@ namespace ToyBox {
         public bool toggleAlignmentFix = false;
         public bool togglePreventAlignmentChanges = false;
         public bool toggleBrutalUnfair = false;
+        public bool highlightHiddenObjects = false;
+        public bool highlightHiddenObjectsInFog = false;
 
         // Loot 
         public bool toggleColorLootByRarity = false;


### PR DESCRIPTION
highlights map objects that have perception checks associated with them; notably: traps, loot, doors

![perception](https://user-images.githubusercontent.com/16431567/135929809-c99ff457-89c7-4d23-806c-c71c21920811.png)
