### PR TITLE
Spells known fixes

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -34,7 +34,7 @@
 * **Crusade Editor**
   * Reworked UI to match design of other parts of the mod
   * Fixed bug where it was displaying the Exp required for the current rank rather than the next rank
-  * (***ArcaneTrixter***) Made spell learning for spontaneous casters less buggy. Still has an issue with certain sources of bonus spells and mega gestalts.
+  * (***ArcaneTrixter***) Made spell learning for spontaneous casters less buggy. Is currently tied to game load and level up, so if you're having issues with spells known try reloading.
 ### Ver 1.3.18
 * **Key Bindings** - now shows conflicting keyBinds
 * **Bag of Tricks**

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -34,6 +34,7 @@
 * **Crusade Editor**
   * Reworked UI to match design of other parts of the mod
   * Fixed bug where it was displaying the Exp required for the current rank rather than the next rank
+  * (***ArcaneTrixter***) Made spell learning for spontaneous casters less buggy. Still has an issue with certain sources of bonus spells and mega gestalts.
 ### Ver 1.3.18
 * **Key Bindings** - now shows conflicting keyBinds
 * **Bag of Tricks**


### PR DESCRIPTION
This is functionally a hack to deal with the fact that reading spell information during level up screen doesn't have information such as whether a spell is temporary, from a scroll, from an item, etc. The calculation logic should be correct, although caching on game load and on level up instead of during the levelup is something of a hack.