### PR TITLE
adds an option to reset failed interaction skill checks

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -25,6 +25,7 @@
   * (***ShadowRanger***) Added a fix that should resolve the zoomed out camera bug if you had both ToyBox and Free Camera installed.  You may need to reset Toybox's fovMultiplier to 1 for it to take effect.
   * (***ShadowRanger***) Added a new sub-menu for all 'begone' versions called ***Icky Stuff Begone!!!*** and added green explainer text
   * (***ShadowRanger***) Added retrievers begone
+  * (***Mafemergency***) Tweak to reset interaction skill checks
 * **Party Editor** 
   * fixed crasher when you lowered caster level multiple times
   * ***Add All*** spells no longer adds extra copies of spells you already learned

--- a/ToyBox/classes/MainUI/Actions.cs
+++ b/ToyBox/classes/MainUI/Actions.cs
@@ -22,6 +22,7 @@ using Kingmaker.UnitLogic;
 using Kingmaker.UnitLogic.Abilities.Blueprints;
 using Kingmaker.UnitLogic.Buffs;
 using Kingmaker.Utility;
+using Kingmaker.View.MapObjects;
 using UnityModManagerNet;
 using ToyBox.BagOfPatches;
 using ModKit;
@@ -359,6 +360,17 @@ namespace ToyBox {
             }
             foreach (var unitEntityData in Game.Instance.State.Units) {
                 unitEntityData.View.UpdateHighlight(false);
+            }
+        }
+
+        public static void RerollInteractionSkillChecks() {
+            foreach (var obj in Game.Instance.State.MapObjects) {
+                foreach (var part in obj.Parts.GetAll<InteractionSkillCheckPart>()) {
+                    if (part.AlreadyUsed && !part.CheckPassed) {
+                        part.AlreadyUsed = false;
+                        part.Enabled = true;
+                    }
+                }
             }
         }
     }

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -32,6 +32,7 @@ namespace ToyBox {
         private const string TeleportPartyToYou = "Teleport Party To You";
         private const string GoToGlobalMap = "Go To Global Map";
         private const string RerollPerception = "Reroll Perception";
+        private const string RerollInteractionSkillChecks = "Reroll Interaction Skill Checks";
         private const string ChangeParty = "Change Party";
 
         // other
@@ -52,6 +53,7 @@ namespace ToyBox {
             KeyBindings.RegisterAction(TeleportPartyToYou, () => Teleport.TeleportPartyToPlayer());
             KeyBindings.RegisterAction(GoToGlobalMap, () => Teleport.TeleportToGlobalMap());
             KeyBindings.RegisterAction(RerollPerception, () => Actions.RunPerceptionTriggers());
+            KeyBindings.RegisterAction(RerollInteractionSkillChecks, () => Actions.RerollInteractionSkillChecks());
             KeyBindings.RegisterAction(ChangeParty, () => { Actions.ChangeParty(); });
             // Other
             KeyBindings.RegisterAction(TimeScaleMultToggle, () => {


### PR DESCRIPTION
interaction skill checks are not to be confused with perception skill checks: perception skill checks are
for hidden objects, and interaction skill checks are for interaction icons (image attached)

![interactionskillcheck](https://user-images.githubusercontent.com/16431567/136638480-fff848f9-e223-4c82-a3b9-dfb0f9feab06.png)
