### PR TITLE
Bigger max buff duration mult

### DIFF
--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -367,7 +367,7 @@ namespace ToyBox {
 
                 },
                 () => LogSlider("Enemy HP Multiplier", ref settings.enemyBaseHitPointsMultiplier, 0.1f, 20, 1, 1, "", AutoWidth()),
-                () => LogSlider("Buff Duration", ref settings.buffDurationMultiplierValue, 0f, 999, 1, 1, "", AutoWidth()),
+                () => LogSlider("Buff Duration", ref settings.buffDurationMultiplierValue, 0f, 9999, 1, 1, "", AutoWidth()),
                 () => LogSlider("Field Of View", ref settings.fovMultiplier, 0.4f, 5.0f, 1, 2, "", AutoWidth()),
                 () => LogSlider("FoV (Cut Scenes)", ref settings.fovMultiplierCutScenes, 0.4f, 5.0f, 1, 2, "", AutoWidth()),
                 () => { }


### PR DESCRIPTION
999 allows for 1 round/lvl spells (like haste) to go to about 20h (+- depending on lvl). That's good, but if someone wants to solve buffing problem with buff duration it's not enough.
9999 allowed for over 16 days for me (I could do the math, but eh), which is much more comfortable. Slider is still fine to use imho (looses some accuracy, but once someone gets into hundreds they shouldn't care about single digit precision anyway). 