### PR TITLE
Bag of Tricks: Armor series

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -41,7 +41,12 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * **Armies Editor** allow editing of leader skills
 * **Etude Editor** Show other Etude info and links 
 ### Ver 1.4.2 (Coming Soon)
-* **Bag of Tricks** moved teleport keys to go with teleport party to me and gave it its own section with explainer text
+* **Bag of Tricks**
+  * moved teleport keys to go with teleport party to me and gave it its own section with explainer text
+  * (***Aephiex***) Renamed 'Disable Arcane Spell Failure' into 'Disable Armor & Shield Arcane Spell Failure' to make it more clear
+  * (***Aephiex***) Fixed issue where 'Disable Armor Max Dexterity' permanently changes armor max dexterity into 99 even after disabling this option
+  * (***Aephiex***) Added new option 'Disable Armor Speed Reduction' which disables the -10 speed while wearing medium and heavy armor
+  * (***Aephiex***) Added new option 'Disable Armor & Shield Checks Penalty' which disables the checks penalty applied while wearing armor and holding shield
 * **Level Up & Multiclass** 
   * Fixed issue where char gen class choices would get applied to companions during some level ups. Please give feedback if you see issues respecing your companions
   * removed unimplemented flags in the multi-class config to avoid confusion. Please file feature requests if there are any that you really wanted.

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -1,4 +1,4 @@
-﻿// Copyright < 2021 > Narria (github user Cabarius) - License: MIT
+// Copyright < 2021 > Narria (github user Cabarius) - License: MIT
 
 using System;
 using System.Linq;
@@ -289,7 +289,6 @@ namespace ToyBox {
                 () => Toggle("Infinite Abilities", ref settings.toggleInfiniteAbilities),
                 () => Toggle("Infinite Spell Casts", ref settings.toggleInfiniteSpellCasts),
                 () => Toggle("No Material Components", ref settings.toggleMaterialComponent),
-                () => Toggle("Disable Arcane Spell Failure", ref settings.toggleIgnoreSpellFailure),
                 () => Toggle("Disable Party Negative Levels", ref settings.togglePartyNegativeLevelImmunity),
                 () => Toggle("Disable Party Ability Damage", ref settings.togglePartyAbilityDamageImmunity),
 
@@ -302,6 +301,9 @@ namespace ToyBox {
 
                 () => Toggle("Disable Equipment Restrictions", ref settings.toggleEquipmentRestrictions),
                 () => Toggle("Disable Armor Max Dexterity", ref settings.toggleIgnoreMaxDexterity),
+                () => Toggle("Disable Armor Speed Reduction", ref settings.toggleIgnoreSpeedReduction),
+                () => Toggle("Disable Armor & Shield Arcane Spell Failure", ref settings.toggleIgnoreSpellFailure),
+                () => Toggle("Disable Armor & Shield Checks Penalty", ref settings.toggleIgnoreArmorChecksPenalty),
 
                 () => Toggle("Disable Dialog Restrictions (Alignment)", ref settings.toggleDialogRestrictions),
                 () => Toggle("Disable Dialog Restrictions (Mythic Path)", ref settings.toggleDialogRestrictionsMythic),

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright < 2021 > Narria (github user Cabarius) - License: MIT
+// Copyright < 2021 > Narria (github user Cabarius) - License: MIT
 using ModKit.Utility;
 using System.Collections.Generic;
 using UnityModManagerNet;
@@ -89,6 +89,8 @@ namespace ToyBox {
         public bool toggleUnlimitedActionsPerTurn = false;
         public bool toggleEquipmentRestrictions = false;
         public bool toggleIgnoreMaxDexterity = false;
+        public bool toggleIgnoreArmorChecksPenalty = false;
+        public bool toggleIgnoreSpeedReduction = false;
         public bool toggleIgnoreSpellFailure = false;
         public bool togglePartyNegativeLevelImmunity = false;
         public bool togglePartyAbilityDamageImmunity = false;

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Tweaks.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Tweaks.cs
@@ -295,7 +295,8 @@ namespace ToyBox.BagOfPatches {
                         __instance.m_Modifiers.ForEach(delegate (ModifiableValue.Modifier m)
                         {
                             ModifiableValue appliedTo = m.AppliedTo;
-                            if (appliedTo == __instance.Wielder.Stats.Speed) {
+                            ModifierDescriptor desc = m.ModDescriptor;
+                            if (appliedTo == __instance.Wielder.Stats.Speed && (desc == ModifierDescriptor.Shield || desc == ModifierDescriptor.Armor)) {
                                 m.Remove();
                             }
                         });


### PR DESCRIPTION
 * Renamed 'Disable Arcane Spell Failure' into 'Disable Armor & Shield Arcane Spell Failure' to make it more clear
 * Fixed issue where 'Disable Armor Max Dexterity' permanently changes armor max dexterity into 99 even after disabling this option
 * Added new option 'Disable Armor Speed Reduction' which disables the -10 speed while wearing medium and heavy armor
 * Added new option 'Disable Armor & Shield Checks Penalty' which disables the checks penalty applied while wearing armor and holding shield

Local tests confirmed to work