### PR TITLE
Update LevelUpPatches.cs

### DIFF
--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUpPatches.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUpPatches.cs
@@ -361,7 +361,7 @@ namespace ToyBox.BagOfPatches {
                     PrerequisiteClassLevel __instance,
                     ref bool __result) {
                 if (!unit.IsPartyOrPet()) return; // don't give extra feats to NPCs
-                if (!__result && settings.toggleIgnorePrerequisiteClassLevel) {
+                if (!__result && settings.toggleIgnorePrerequisiteClassLevel && !__instance.HideInUI) {
                     var characterClass = (BlueprintCharacterClass)(__instance.m_CharacterClass).GetBlueprint();
                     if (!characterClass.HideIfRestricted && !characterClass.IsMythic)
                         __result = true;


### PR DESCRIPTION
A fighter in horse gear? A bad idea. This edit excludes animal companions and mythic classes from the cheat, less likely to bug out.
It also excludes the glitched duplicate of Eldrich Scion from class selection.
Additionally, it fixes the issue where Dragon Disciple can be selected unconditionally.