### PR TITLE
Fix for stack merging eating enchants -  EX: If you add mighty fists …

### DIFF
--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -150,6 +150,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="classes\CustomEnchantmentStackingFix.cs" />
     <Compile Include="classes\Infrastructure\Borrowed\SmartConsole.cs" />
     <Compile Include="classes\Infrastructure\HumanFriendly.cs" />
     <Compile Include="classes\Infrastructure\Borrowed\StateReplacer.cs" />
@@ -267,7 +268,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties info_1json__JsonSchema="https://json.schemastore.org/global.json" config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" />
+      <UserProperties config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" info_1json__JsonSchema="https://json.schemastore.org/global.json" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/ToyBox/classes/CustomEnchantmentStackingFix.cs
+++ b/ToyBox/classes/CustomEnchantmentStackingFix.cs
@@ -1,0 +1,39 @@
+﻿using HarmonyLib;
+using Kingmaker.Blueprints;
+using Kingmaker.Items;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ToyBox {
+    //Fix for enchants added with toybox getting erased by stack merges - EX: If you add mighty fists to an amulet of natural armor, then stick it in inventory where you have another natural armor amulet of the same type, they're merged into a stack and the mighty fists enchant vanishes
+    class CustomEnchantmentStackingFix {
+        [HarmonyPatch(typeof(ItemEntity), "CanBeMerged", new Type[] { typeof(ItemEntity) })]
+        static class Mergeupgrade {
+            public static void Postfix(ref bool __result, ItemEntity __instance, ItemEntity other) {
+                if (__result) {
+                    if (!(__instance is ItemEntityUsable) && !(other is ItemEntityUsable)) {
+
+                        if (__instance.Enchantments.Count != other.Enchantments.Count)//This catches every case but same number of new enchants added
+                        {
+
+                            __result = false;
+                            return;
+                        }
+                        else if (__instance.Enchantments.Select(x => x.Blueprint.ToReference<BlueprintItemEnchantmentReference>()).Except(other.Enchantments.Select(x => x.Blueprint.ToReference<BlueprintItemEnchantmentReference>())).Any()) //And this catches the rest
+                            {
+
+                            return;
+                        }
+
+
+
+                    }
+                }
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
…to an amulet of natural armor, then stick it in inventory where you have another natural armor amulet of the same type, they're merged into a stack and the mighty fists enchant vanishes.

If you're using the enchant adder as, say, a placeholder for a craft magic items mod, this is very annoying.

File with postfix put into classes directory because I have no idea where you'd want it.