### PR TITLE
Removed Lich romance restriction as part of the Free Love toggle

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -45,6 +45,8 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * ** Bag of Tricks ** > **Quality of Life**
   * Remote Companion Dialog - Allow remote companions to make comments on dialog you are having
     * This is exeprimental and may not work in some cases 
+  * **Love is Free**
+    * Lich path no longer blocks romance
 * **Level Up**
   * (***Truinto***) Unlock Party Level Cap (continuous or exponential)
 * **Enchantment**

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Romance.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Romance.cs
@@ -66,6 +66,43 @@ namespace ToyBox.BagOfPatches {
             }
         }
 
+        // Lich Romance Overrides
+        // These modify the EtudeStatus condition for specific Owner blueprints 
+        internal static readonly Dictionary<(string, string), bool> ConditionCheckOverridesLich = new()
+        {
+            { ("7f532b681d64f3741a7aa0aebba7c4db", "977f3380-2938-4cc8-a26a-448edc6f9259"), false },  // Etude CamelliaRomance_Start status is:  Not Playing;   
+            { ("7f532b681d64f3741a7aa0aebba7c4db", "52632774-cbb4-4eea-ada6-37ec2708e07d"), false },  // Etude WenduagRomance_Active status is:  Not Playing;   
+            { ("7f532b681d64f3741a7aa0aebba7c4db", "12928be5-97e8-4e7c-ac5c-02d704289e7f"), false },  // Etude LannRomance_Active status is:  Not Playing;      
+            { ("7f532b681d64f3741a7aa0aebba7c4db", "2bbad7a7-5918-4c14-b909-f1a7bbce9248"), false },  // Etude ArueshalaeRomance_Active status is:  Not Playing;   
+            { ("7f532b681d64f3741a7aa0aebba7c4db", "55fd2fa2-9644-462a-a02e-23987e05fd62"), false },  // Etude DaeranRomance_Active status is:  Not Playing;      
+            { ("7f532b681d64f3741a7aa0aebba7c4db", "b0f684c1-0cc9-4ec7-a4a3-fe47e3d9847c"), false },  // Etude SosielRomance_Active status is:  Not Playing; 
+        };
+        internal static readonly Dictionary<string, bool> EtudeStatusOverridesLich = new()
+        {
+            { "2ebd861e55143014c8067c6832cdf21c", false },  // Cue_0048
+        };
+
+        [HarmonyPatch(typeof(Condition), nameof(Condition.Check))]
+        public static class Condition_Check_Patch_Lich
+        {
+            public static void Postfix(Condition __instance, ref bool __result)
+            {
+                if (!settings.toggleAllowAnyGenderRomance || __instance?.Owner is null) return;
+                var keyLich = (__instance.Owner.AssetGuid.ToString(), __instance.AssetGuid);
+                if (ConditionCheckOverridesLich.TryGetValue(keyLich, out var valueLich)) { Mod.Debug($"overiding {(__instance.Owner.name, __instance.name)} to {valueLich}"); __result = valueLich; }
+            }
+        }
+
+        [HarmonyPatch(typeof(EtudeStatus), nameof(EtudeStatus.CheckCondition))]
+        public static class EtudeStatus_CheckCondition_Patch_Lich
+        {
+            public static void Postfix(EtudeStatus __instance, ref bool __result)
+            {
+                if (!settings.toggleAllowAnyGenderRomance || __instance?.Owner is null) return;
+                if (EtudeStatusOverridesLich.TryGetValue(__instance.Owner.AssetGuid.ToString(), out var valueLich)) { Mod.Debug($"overiding {__instance.Owner.name} to {valueLich}"); __result = valueLich; }
+            }
+        }
+
         // Multiple Romances overrides
         // This modify the EtudeStatus condition for specific Owner blueprints 
         internal static readonly Dictionary<(string, string), bool> ConditionCheckOverrides = new() {


### PR DESCRIPTION
Used Etude overrides for specific BPs to remove the Lich path's method of disabling romances.