### PR TITLE
Fix for crash on null BlueprintItemEnchantment comment/prefix/suffix

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -58,6 +58,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
   * Show enchament rating
   * Improved sorting of enchaments
   * Show character name equiping an item if is equiped
+  * Fixed crash on null comment/prefix/suffix in BlueprintItemEnchantment (pheonix99)
 * **Loot**
   * Item rarity takes into account enchantment rarity
 * **Armies Editor**

--- a/ToyBox/classes/MainUI/EnchantmentEditor.cs
+++ b/ToyBox/classes/MainUI/EnchantmentEditor.cs
@@ -336,9 +336,9 @@ namespace ToyBox.classes.MainUI {
                     UI.Label($"{enchant.Rating()}".yellow(), 75.width()); // ⊙
                     UI.Space(10);
                     var description = enchant.Description.StripHTML().green();
-                    if (enchant.Comment.Length > 0) description = enchant.Comment.orange() + " " + description;
-                    if (enchant.Prefix.Length > 0) description = enchant.Prefix.yellow() + " " + description;
-                    if (enchant.Suffix.Length > 0) description = enchant.Suffix.yellow() + " " + description;
+                    if (enchant.Comment?.Length > 0) description = enchant.Comment.orange() + " " + description;
+                    if (enchant.Prefix?.Length > 0) description = enchant.Prefix.yellow() + " " + description;
+                    if (enchant.Suffix?.Length > 0) description = enchant.Suffix.yellow() + " " + description;
                     if (settings.showAssetIDs) {
                         using (UI.VerticalScope()) {
                             using (UI.HorizontalScope()) {


### PR DESCRIPTION
If comment, prefix or suffix were null in on a BlueprintItemEnchantment, EnchantmentListGUI would have an NPE.

Now it won't.