### PR TITLE
patches to display guid in most tooltips; shift + left click on item/…

### DIFF
--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -79,7 +79,8 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Owlcat.Runtime.Validation">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Pathfinder Second Adventure\Wrath_Data\Managed\Owlcat.Runtime.Validation.dll</HintPath>
+      <HintPath>$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.Validation.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Owlcat.Runtime.Visual">
       <HintPath>$(WrathPath)\Wrath_Data\Managed\Owlcat.Runtime.Visual.dll</HintPath>
@@ -206,6 +207,7 @@
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\ActionBar.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Alignment.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Camera.cs" />
+    <Compile Include="classes\MonkeyPatchin\BagOfPatches\Clipboard+Guids.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Combat\Actions.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Combat\NoFriendlyFire.cs" />
     <Compile Include="classes\MonkeyPatchin\BagOfPatches\Crusade.cs" />
@@ -283,7 +285,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties info_1json__JsonSchema="https://json.schemastore.org/global.json" config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" />
+      <UserProperties config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" info_1json__JsonSchema="https://json.schemastore.org/global.json" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/ToyBox/classes/Models/Settings+UI.cs
+++ b/ToyBox/classes/Models/Settings+UI.cs
@@ -30,6 +30,7 @@ namespace ToyBox {
 #if DEBUG
                 () => UI.Toggle("Strip HTML (colors) from Logs Tab in Unity Mod Manager", ref Main.settings.stripHtmlTagsFromUMMLogsTab),
 #endif
+                () => UI.Toggle("Display guids in most tooltips, use shift + left click on items/abilities to copy guid to clipboard", ref Main.settings.toggleGuidsClipboard),
               () => { }
             );
 #if DEBUG

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -432,6 +432,7 @@ namespace ToyBox {
         public bool toggleShowDebugInfo = true;
         public bool toggleDevopmentMode = false;
         public bool toggleUberLoggerForwardPrefix = false;
+        public bool toggleGuidsClipboard = true;
 
         // Localization
         public string uiCultureCode = "en";

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Clipboard+Guids.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Clipboard+Guids.cs
@@ -86,7 +86,7 @@ namespace ToyBox.classes.MonkeyPatchin.BagOfPatches {
             if (!settings.toggleGuidsClipboard)
                 return true;
 
-            if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)) {
+            if (Input.GetMouseButtonUp(0) && (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))) {
                 switch (__instance.MechanicActionBarSlot) {
                     case MechanicActionBarSlotAbility ab:
                         CopyToClipboard(ab.Ability.Blueprint.AssetGuidThreadSafe);

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Clipboard+Guids.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Clipboard+Guids.cs
@@ -1,0 +1,125 @@
+﻿using HarmonyLib;
+using Kingmaker.PubSubSystem;
+using Kingmaker.UI.MVVM._PCView.Slots;
+using Kingmaker.UI.MVVM._VM.ActionBar;
+using Kingmaker.UI.MVVM._VM.Tooltip.Bricks;
+using Kingmaker.UI.MVVM._VM.Tooltip.Templates;
+using Kingmaker.UI.UnitSettings;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace ToyBox.classes.MonkeyPatchin.BagOfPatches {
+
+    [HarmonyPatch]
+    public class Clipboard_Guids {
+        public static Settings settings = Main.settings;
+        public static void CopyToClipboard(string guid) {
+            GUIUtility.systemCopyBuffer = guid;
+            EventBus.RaiseEvent<IWarningNotificationUIHandler>(h => h.HandleWarning("Copied Guid to clipboard: " + guid, false));
+        }
+
+        [HarmonyPatch(typeof(TooltipTemplateAbility), nameof(TooltipTemplateAbility.GetBody))]
+        [HarmonyPostfix]
+        public static void Tooltip1(TooltipTemplateAbility __instance, ref IEnumerable<ITooltipBrick> __result) {
+            if (!settings.toggleGuidsClipboard)
+                return;
+
+            var list = __result.ToList();
+
+            var guid = __instance.BlueprintAbility?.AssetGuidThreadSafe;
+            list.Insert(0, new TooltipBrickText($"<color=grey>guid: {guid}</color>", TooltipTextType.Small | TooltipTextType.Italic));
+
+            __result = list;
+        }
+
+        [HarmonyPatch(typeof(TooltipTemplateActivatableAbility), nameof(TooltipTemplateActivatableAbility.GetBody))]
+        [HarmonyPostfix]
+        public static void Tooltip2(TooltipTemplateActivatableAbility __instance, ref IEnumerable<ITooltipBrick> __result) {
+            if (!settings.toggleGuidsClipboard)
+                return;
+
+            var list = __result.ToList();
+
+            var guid = __instance.BlueprintActivatableAbility?.AssetGuidThreadSafe;
+            var guid2 = __instance.BlueprintActivatableAbility?.m_Buff?.Guid.ToString();
+            list.Insert(0, new TooltipBrickText($"<color=grey>guid: {guid}\nbuff: {guid2}</color>", TooltipTextType.Small | TooltipTextType.Italic));
+
+            __result = list;
+        }
+
+        [HarmonyPatch(typeof(TooltipTemplateItem), nameof(TooltipTemplateItem.GetBody))]
+        [HarmonyPostfix]
+        public static void Tooltip3(TooltipTemplateItem __instance, ref IEnumerable<ITooltipBrick> __result) {
+            if (!settings.toggleGuidsClipboard)
+                return;
+
+            var list = __result.ToList();
+
+            var guid = __instance.m_BlueprintItem?.AssetGuidThreadSafe ?? __instance.m_Item?.Blueprint?.AssetGuidThreadSafe;
+            list.Insert(0, new TooltipBrickText($"<color=grey>guid: {guid}</color>", TooltipTextType.Small | TooltipTextType.Italic));
+
+            __result = list;
+        }
+
+        [HarmonyPatch(typeof(TooltipTemplateBuff), nameof(TooltipTemplateBuff.GetBody))]
+        [HarmonyPostfix]
+        public static void Tooltip4(TooltipTemplateBuff __instance, ref IEnumerable<ITooltipBrick> __result) {
+            if (!settings.toggleGuidsClipboard)
+                return;
+
+            var list = __result.ToList();
+
+            var guid = __instance.Buff?.Blueprint?.AssetGuidThreadSafe;
+            list.Insert(0, new TooltipBrickText($"<color=grey>guid: {guid}</color>", TooltipTextType.Small | TooltipTextType.Italic));
+
+            __result = list;
+        }
+
+        [HarmonyPatch(typeof(ActionBarSlotVM), nameof(ActionBarSlotVM.OnMainClick))]
+        [HarmonyPrefix]
+        [HarmonyPriority(390)]
+        public static bool LeftClickToolbar(ActionBarSlotVM __instance) {
+            if (!settings.toggleGuidsClipboard)
+                return true;
+
+            if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)) {
+                switch (__instance.MechanicActionBarSlot) {
+                    case MechanicActionBarSlotAbility ab:
+                        CopyToClipboard(ab.Ability.Blueprint.AssetGuidThreadSafe);
+                        return false;
+                    case MechanicActionBarSlotActivableAbility act:
+                        CopyToClipboard(act.ActivatableAbility.Blueprint.AssetGuidThreadSafe);
+                        return false;
+                    case MechanicActionBarSlotItem item:
+                        CopyToClipboard(item.Item.Blueprint.AssetGuidThreadSafe);
+                        return false;
+                    case MechanicActionBarSlotSpell spell:
+                        CopyToClipboard(spell.Spell.Blueprint.AssetGuidThreadSafe);
+                        return false;
+                    case MechanicActionBarSlotSpontaneusConvertedSpell cspell:
+                        CopyToClipboard(cspell.Spell.Blueprint.AssetGuidThreadSafe);
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        [HarmonyPatch(typeof(ItemSlotPCView), nameof(ItemSlotPCView.OnClick))]
+        [HarmonyPrefix]
+        public static void LeftClickItem(ItemSlotPCView __instance) {
+            if (!settings.toggleGuidsClipboard)
+                return;
+
+            if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift)) {
+                string guid = __instance.ViewModel?.Item?.Value?.Blueprint?.AssetGuidThreadSafe;
+                if (guid != null)
+                    CopyToClipboard(guid);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Logic and settings to display guid in most tooltips. Shift + left click on item/ability icons copies guid to clipboard. Tested.

Also fixed faulty reference to Owlcat.Runtime.Validation.