### PR TITLE
add button to reveal dlc portal loot

### DIFF
--- a/ToyBox/classes/Infrastructure/LootHelper.cs
+++ b/ToyBox/classes/Infrastructure/LootHelper.cs
@@ -1,7 +1,9 @@
 ﻿using Kingmaker;
 using Kingmaker.Blueprints.Loot;
+using Kingmaker.Designers.EventConditionActionSystem.Actions;
 using Kingmaker.EntitySystem;
 using Kingmaker.EntitySystem.Entities;
+using Kingmaker.EntitySystem.Stats;
 using Kingmaker.Items;
 using Kingmaker.UI.MVVM._PCView.Loot;
 using Kingmaker.UI.MVVM._VM.Loot;
@@ -95,6 +97,19 @@ namespace ToyBox {
             foreach (var interactionLootPart in interactionLootParts) {
                 if (hidden) interactionLootPart.Owner.IsPerceptionCheckPassed = true;
                 interactionLootPart.Owner.SetIsRevealedSilent(true);
+            }
+        }
+
+        public static void ShowAllInevitablePortalLoot() {
+            var interactionLootRevealers = Game.Instance.State.MapObjects.All.OfType<MapObjectEntityData>()
+                .Where(e => e.IsInGame)
+                .SelectMany(e => e.Interactions).OfType<InteractionSkillCheckPart>().NotNull()
+                .Where(i => i.Settings?.DC == 0 && i.Settings.Skill == StatType.Unknown)
+                .SelectMany(i => i.Settings?.CheckPassedActions?.Get()?.Actions?.Actions).OfType<HideMapObject>().NotNull()
+                .Where(a => a.Unhide)
+                .Where(a => a.MapObject.GetValue()?.Get<InteractionLootPart>() is not null);
+            foreach (var revealer in interactionLootRevealers) {
+                revealer.RunAction();
             }
         }
     }

--- a/ToyBox/classes/MainUI/PhatLoot.cs
+++ b/ToyBox/classes/MainUI/PhatLoot.cs
@@ -54,6 +54,10 @@ namespace ToyBox {
                     UI.Space(210); UI.Label("Shows all chests/bags/etc on the map including hidden".green());
                 },
                 () => {
+                    UI.ActionButton("Reveal Inevitable Loot", () => LootHelper.ShowAllInevitablePortalLoot(), UI.Width(200));
+                    UI.Space(210); UI.Label("Shows unlocked Inevitable Excess DLC rewards on the map".green());
+                },
+                () => {
                     UI.Toggle("Mass Loot Shows Everything When Leaving Map", ref settings.toggleMassLootEverything);
                     UI.Space(100); UI.Label("Some items might be invisible until looted".green());
                 },


### PR DESCRIPTION
If the portal is revealed, this button reveals the associated loot.

Only found one portal so far, so this needs more testing.