### PR TITLE
New buffs for multiplier exclusion list

### DIFF
--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
@@ -138,7 +138,9 @@ namespace ToyBox.BagOfPatches {
 
         private static readonly string[] badBuffs = new string[] {
             "24cf3deb078d3df4d92ba24b176bda97", //Prone
-            "e6f2fc5d73d88064583cb828801212f4" //Fatigued
+            "e6f2fc5d73d88064583cb828801212f4", //Fatigued
+            "bb1b849f30e6464284c1efd0e812d626", //Army Nauseated
+            "f59aa0658cda4c7b82bf73c632a39650", //Army Stinking Cloud
         };
 
         private static bool isGoodBuff(BlueprintBuff blueprint) => !blueprint.Harmful && !badBuffs.Contains(blueprint.AssetGuidThreadSafe);


### PR DESCRIPTION
It looks like negative army buffs may not be marked as harmful in their blueprints. I noticed these so far, but I'm sure there are others.

Side note - maybe it'd be worthwhile to allow exceptions to be user configurable? Maybe even an "exclude from multipliers" button when inspecting an individual buff (on the screen that shows the GUID for the buff) would be an easy option (then it could be stored in a list).