### PR TITLE
Add an exception list UI for buff durations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+
+#Visual Studio Code options directory
+.vscode/
+
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -40,6 +40,8 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 ***Important**: *Make sure you are on the latest version of the game 1.0.8e or newer*
 ### Ver 1.4.18
 * (***BuckAMayzing***) Fixed a bug where a couple of army debuffs (Nauseated, Stinking Cloud) were incorrectly being multiplied by the buff duration multiplier.
+* (***BuckAMayzing***) Fixed a bug which caused Vertical regions to crash the UI.
+* (***BuckAMayzing***) Added configurability for buffs to exclude from buff duration multiplier in Bag of Tricks.
 ### Ver 1.4.17 (DLC 3 release 1.4.2a)
 * Support for Beta 1.4.2a
 ### Ver 1.4.16 (DLC 2 release 1.3.0k)

--- a/ToyBox/ToyBox.csproj
+++ b/ToyBox/ToyBox.csproj
@@ -166,10 +166,12 @@
     <Compile Include="classes\Infrastructure\CasterHelpers.cs" />
     <Compile Include="classes\Infrastructure\ItemRarity.cs" />
     <Compile Include="classes\Infrastructure\LootHelper.cs" />
+    <Compile Include="classes\Infrastructure\SettingsDefaults.cs" />
     <Compile Include="classes\Infrastructure\Teleport.cs" />
     <Compile Include="classes\Infrastructure\Utils.cs" />
     <Compile Include="classes\Infrastructure\WrathExtensions.cs" />
     <Compile Include="classes\Infrastructure\BlueprintExtensions.cs" />
+    <Compile Include="classes\MainUI\Browser\BuffExclusionEditor.cs" />
     <Compile Include="classes\MainUI\Browser\EditorActions.cs" />
     <Compile Include="classes\MainUI\Browser\Editor.cs" />
     <Compile Include="classes\MainUI\Crusade\ArmiesEditor.cs" />
@@ -285,7 +287,7 @@
   </PropertyGroup>
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" info_1json__JsonSchema="https://json.schemastore.org/global.json" />
+      <UserProperties info_1json__JsonSchema="https://json.schemastore.org/global.json" config_4bindings_1json__JsonSchema="https://json.schemastore.org/global.json" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/ToyBox/classes/Infrastructure/SettingsDefaults.cs
+++ b/ToyBox/classes/Infrastructure/SettingsDefaults.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace ToyBox {
+    internal static class SettingsDefaults {
+        public static readonly HashSet<string> DefaultBuffsToIgnoreForDurationMultiplier = new() {
+            "24cf3deb078d3df4d92ba24b176bda97", //Prone
+            "e6f2fc5d73d88064583cb828801212f4", //Fatigued
+            "bb1b849f30e6464284c1efd0e812d626", //Army Nauseated
+            "f59aa0658cda4c7b82bf73c632a39650", //Army Stinking Cloud 
+        };
+    }
+}

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -45,6 +45,9 @@ namespace ToyBox {
         private const string PreviewDialogResults = "Preview Results";
         private const string ResetAdditionalCameraAngles = "Fix Camera";
 
+        //For buffs exceptions
+        private static bool showBuffDurationExceptions = false;
+        
         public static void OnLoad() {
             // Combat
             KeyBindings.RegisterAction(RestAll, () => CheatsCombat.RestAll());
@@ -547,6 +550,12 @@ namespace ToyBox {
                 },
                 () => LogSlider("Enemy HP Multiplier", ref settings.enemyBaseHitPointsMultiplier, 0.1f, 20, 1, 1, "", AutoWidth()),
                 () => LogSlider("Buff Duration", ref settings.buffDurationMultiplierValue, 0f, 9999, 1, 1, "", AutoWidth()),
+                () => DisclosureToggle("Exceptions to Buff Duration Multiplier (Advanced; will cause blueprints to load)", ref showBuffDurationExceptions),
+                () => {
+                    if (!showBuffDurationExceptions) return;
+
+                    BuffExclusionEditor.OnGUI();
+                },
                 () => { }
                 );
             Actions.ApplyTimeScale();

--- a/ToyBox/classes/MainUI/BlueprintLoader.cs
+++ b/ToyBox/classes/MainUI/BlueprintLoader.cs
@@ -7,6 +7,7 @@ using Kingmaker.Blueprints;
 using Kingmaker.BundlesLoading;
 using ModKit;
 using System;
+using Kingmaker.Blueprints.Facts;
 
 namespace ToyBox {
 
@@ -125,6 +126,13 @@ namespace ToyBox {
             var bps = GetBlueprints();
             return bps?.OfType<BPType>().ToList() ?? null;
         }
+
+        private IEnumerable<BPType> GetBlueprintsByGuids<BPType>(IEnumerable<BlueprintGuid> guids) where BPType: BlueprintFact {
+            var bps = GetBlueprints<BPType>();
+            return bps?.Where(bp => guids.Contains(bp.AssetGuid));
+        }
+        
+        public IEnumerable<BPType> GetBlueprintsByGuids<BPType>(IEnumerable<string> guids) where BPType: BlueprintFact => GetBlueprintsByGuids<BPType>(guids.Select(g => BlueprintGuid.Parse(g)));
     }
 
     public static class BlueprintLoader<BPType> {

--- a/ToyBox/classes/MainUI/Browser/BuffExclusionEditor.cs
+++ b/ToyBox/classes/MainUI/Browser/BuffExclusionEditor.cs
@@ -1,0 +1,141 @@
+﻿using UnityEngine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Kingmaker.Blueprints;
+using ModKit;
+using static ModKit.UI;
+using Kingmaker.UnitLogic.Buffs.Blueprints;
+
+namespace ToyBox {
+    public class BuffExclusionEditor {
+        public delegate void NavigateTo(params string[] argv);
+        public static Settings settings => Main.settings;
+
+        //We'll use this to add new buffs
+        private static string _userSuppliedGuid = "";
+        private static string _lastValidatedGuid = "";
+        private static List<BlueprintBuff> _buffExceptions;
+
+
+        public static void OnGUI(
+        ) {
+            if (_buffExceptions == null) {
+                _buffExceptions = BlueprintLoader.Shared.GetBlueprintsByGuids<BlueprintBuff>(settings.buffsToIgnoreForDurationMultiplier)?.ToList();
+            }
+            VStack(null,
+
+                () => {
+                    if (BlueprintLoader.Shared.IsLoading) {
+                        Label("Blueprints".orange().bold() + " loading: " + BlueprintLoader.Shared.progress.ToString("P2").cyan().bold());
+                    }
+                    else Space(25);
+                },
+                () => {
+                    if (BlueprintLoader.Shared.IsLoading || _buffExceptions == null) return;
+
+                    using (VerticalScope()) {
+                        AddBuffGui();
+                        if (_buffExceptions != null) {
+                            BuffList(_buffExceptions);
+                        }
+                    }
+                },
+                () => { }
+            );
+
+        }
+
+        private static void AddBuffGui() {
+            using (VerticalScope()) {
+                Label("This section is for excluding (usually harmful) buffs from the buff duration multiplier, since not all harmful buffs are properly tagged as harmful. To add a buff, first find its GUID, which can be done either in-game (with the settings -> \"display guids in most tooltips\" option turned on) or by using Search n' Pick. Once you've added a GUID, click validate. This will verify that the GUID belongs to a valid buff, and reveal an \"Add\" button. Then just click the button to exclude the buff from the duration multiplier!"
+                    .orange().bold());
+                Space(10);
+                Label("Note: the defaults for this list cannot be removed, and have their \"Remove\" buttons hidden."
+                    .orange().bold());
+                Space(25);
+                HStack("Add a new buff", 1, () => {
+                    Label("GUID of Buff:");
+                    Space(25);
+                    TextField(ref _userSuppliedGuid, null, Width(300));
+                    ActionButton("Validate", () => {
+                        if (IsValidBuff(_userSuppliedGuid)) _lastValidatedGuid = _userSuppliedGuid;
+                    });
+                    if (!string.IsNullOrEmpty(_lastValidatedGuid) && _userSuppliedGuid == _lastValidatedGuid) {
+                        ActionButton("Add", () => {
+                            AddABuff(_userSuppliedGuid);
+                            _lastValidatedGuid = "";
+                            _userSuppliedGuid = "";
+                        });
+                        Space(25);
+                        Label("It's a valid Buff! Press \"Add\" to add it to the list.".green());
+                    }
+
+                });
+            }
+
+        }
+
+        private static void BuffList(IEnumerable<BlueprintBuff> buffs) {
+            var divisor = IsWide ? 6 : 4;
+            var titleWidth = ummWidth / divisor;
+            var complexNameWidth = ummWidth / divisor;
+            VStack(null, buffs?.OrderBy(b => b.GetDisplayName()).Select<BlueprintBuff, Action>(bp => () => {
+                using (HorizontalScope()) {
+                    Label(bp.GetDisplayName().cyan().bold(), Width(titleWidth));
+                    Label(bp.NameSafe().orange().bold(), Width(complexNameWidth));
+                    Space(25);
+                    GUILayout.TextField(bp.AssetGuidThreadSafe, ExpandWidth(false));
+                    if (!SettingsDefaults.DefaultBuffsToIgnoreForDurationMultiplier.Contains(bp.AssetGuidThreadSafe)) {
+                        //It seems that if you specify defaults, saving settings without the defaults won't actually
+                        //remove the items from the list. This just prevents confusion by removing the button altogether.
+                        ActionButton("Remove", () => {
+                            RemoveABuff(bp.AssetGuidThreadSafe);
+                        });
+                    }
+                    Label(bp.GetDescription().green());
+                }
+                Space(25);
+            })
+            .Prepend(() => {
+                using (HorizontalScope()) {
+                    Label("In-Game Name".red().bold(), Width(titleWidth));
+                    Label("Internal Name".red().bold(), Width(complexNameWidth));
+                }
+            })
+            .Append(() => { })
+            .ToArray());
+        }
+
+        private static void AddABuff(string buffGuid) {
+            if (!IsValidBuff(buffGuid)) return;
+
+            settings.buffsToIgnoreForDurationMultiplier.Add(buffGuid);
+            TriggerReload();
+#if DEBUG
+            LogCurrentlyIgnoredBuffs();
+#endif
+        }
+
+        private static void RemoveABuff(string buffGuid) {
+            if (!settings.buffsToIgnoreForDurationMultiplier.Contains(buffGuid)) return;
+
+            settings.buffsToIgnoreForDurationMultiplier.Remove(buffGuid);
+            TriggerReload();
+#if DEBUG
+            LogCurrentlyIgnoredBuffs();
+#endif
+        }
+
+        private static void TriggerReload() {
+            _buffExceptions = null;
+        }
+
+
+        private static void LogCurrentlyIgnoredBuffs() => Mod.Log($"Currently ignored buffs: {string.Join(", ", settings.buffsToIgnoreForDurationMultiplier)}");
+
+
+        public static bool IsValidBuff(string buffGuid) => BlueprintLoader.Shared.GetBlueprintsByGuids<BlueprintBuff>(new[] { buffGuid }).Count() > 0;
+
+    }
+}

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -424,6 +424,7 @@ namespace ToyBox {
         public HashSet<string> ignoredEquipmentRestrictionSet = new();
         public bool toggleIgnoreBuildingRestrictions = false;
         public HashSet<string> ignoredBuildingRestrictionSet = new();
+        public HashSet<string> buffsToIgnoreForDurationMultiplier = new(SettingsDefaults.DefaultBuffsToIgnoreForDurationMultiplier);
 
         // Development
         public LogLevel loggingLevel = LogLevel.Info;

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
@@ -136,12 +136,7 @@ namespace ToyBox.BagOfPatches {
 #endif
 
 
-        private static readonly string[] badBuffs = new string[] {
-            "24cf3deb078d3df4d92ba24b176bda97", //Prone
-            "e6f2fc5d73d88064583cb828801212f4", //Fatigued
-            "bb1b849f30e6464284c1efd0e812d626", //Army Nauseated
-            "f59aa0658cda4c7b82bf73c632a39650", //Army Stinking Cloud
-        };
+        private static readonly HashSet<string> badBuffs = settings.buffsToIgnoreForDurationMultiplier;
 
         private static bool isGoodBuff(BlueprintBuff blueprint) => !blueprint.Harmful && !badBuffs.Contains(blueprint.AssetGuidThreadSafe);
 


### PR DESCRIPTION
IMPORTANT: this is dependent on #687. This change will break the UI otherwise.

Just like on #687, I'll add this to #684 if you approve these changes, then the changelog can be up to date (avoiding merge conflict).

UPDATE:
I tweaked the UI after our conversation. This gets it closer to in-line with other parts of the application, though I did think it was worthwhile to do a couple of things differently:

Firstly, the buffs are split into two lists: the current exclusion list, and everything else.

Current exclusion:
![image](https://user-images.githubusercontent.com/19292614/194991975-17f9bce8-c450-4f09-b775-b75e99987cee.png)

Everything else:
![image](https://user-images.githubusercontent.com/19292614/194992252-6e9d8fab-0f32-4e7f-a357-b84b7f8ca7a7.png)
Pagination is on top & bottom of the control:
![image](https://user-images.githubusercontent.com/19292614/194992298-19c5f44b-9069-4124-8d24-048c6352cd5d.png)

When clicking "Add", items are moved from the bottom list to the top. Pagination stays intact.

Search performance is quite good, taking milliseconds (it's case sensitive, but it looks like other search dialogs are too).

Note the pagination control will update page numbers (and clamp the current page number if you're out of bounds):
![image](https://user-images.githubusercontent.com/19292614/194992508-8d3ce967-382b-476f-8308-f6b0d3d4b65c.png)

Show GUIDs is respected, though it feels a bit awkward to have to go over to Search n' Pick to turn it on/off:
![image](https://user-images.githubusercontent.com/19292614/194992624-0f5e9622-1ef5-4865-bfb5-1b9bcf15f185.png)

Finally, each list has independent controls for visibility: 
![image](https://user-images.githubusercontent.com/19292614/194992801-0674294b-d540-4f29-972a-b629e4ca8c81.png)


