### PR TITLE
Fix Multiclass/Gestalt on DLC Player/Mercenary Respec

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -37,6 +37,8 @@ Enchantment: allows you to add or remove enchantments from the items in your inv
 WARNING: this tool can both miraculously fix your broken progression or it can break it even further. Save and back up your save before using. Remember that "with great power comes great responsibility"
 * **Quest Resolution**: this allows you to view your active quests and advance them as needed to work around bugs or skip quests you don't want to do.  Be warned this may break your game progression if used carelessly.
 
+### Ver 1.4.20
+* (***AeonBlack***) Fix Multiclass/Gestalt on DLC Player/Mercenary Respec. (Note: Still broken on Mercenary Recruit, Workaround: Hire and then Respec through Party Editor.)
 ### Ver 1.4.19
 ***Important**: *Make sure you are on the latest version of the game 2.0.4j or newer*
 * (***ArcaneTrixter***) Ignore Class Restrictions now works for mythic classes as well, regardless of quest and etude states.

--- a/ToyBox/classes/Models/Settings+Multiclass.cs
+++ b/ToyBox/classes/Models/Settings+Multiclass.cs
@@ -28,7 +28,7 @@ namespace ToyBox {
         public static MulticlassOptions Get(UnitDescriptor ch) {
             //Main.Log($"stack: {System.Environment.StackTrace}");
             MulticlassOptions options;
-            if (ch == null || ch.CharacterName == "Knight Commander") {
+            if (ch == null || ch.CharacterName == "Knight Commander" || ch.CharacterName == "Player Character") {
                 options = Main.settings.multiclassSettings.GetValueOrDefault(CharGenKey, new MulticlassOptions());
                 //Mod.Debug($"MulticlassOptions.Get - chargen - options: {options}");
             }
@@ -66,7 +66,7 @@ namespace ToyBox {
         }
         public static void Set(UnitDescriptor ch, MulticlassOptions options) {
             //modLogger.Log($"stack: {System.Environment.StackTrace}");
-            if (ch == null || ch.CharacterName == "Knight Commander") 
+            if (ch == null || ch.CharacterName == "Knight Commander" || ch.CharacterName == "Player Character") 
                 Main.settings.multiclassSettings[CharGenKey] = options;
             else {
                 if (ch.HashKey() == null) return;

--- a/ToyBox/classes/MonkeyPatchin/Multiclass/MulticlassMod.cs
+++ b/ToyBox/classes/MonkeyPatchin/Multiclass/MulticlassMod.cs
@@ -82,7 +82,7 @@ namespace ToyBox.Multiclass {
             var companionNames = Game.Instance?.Player?.AllCharacters.Where(c => !c.IsMainCharacter).Select(c => c.CharacterName).ToList();
             var isCompanion = companionNames?.Contains(state.Unit.CharacterName) ?? false;
             if (isCompanion) return false;
-            return state.Mode == LevelUpState.CharBuildMode.CharGen || state.Unit.CharacterName == "Player Character";
+            return state.Mode == LevelUpState.CharBuildMode.CharGen || state.Unit.CharacterName == "Player Character" || state.IsFirstCharacterLevel;
         }
 
         public static bool IsLevelUp(this LevelUpState state) => state.Mode == LevelUpState.CharBuildMode.LevelUp;


### PR DESCRIPTION
Should fix up a few issues where multiclass failed to apply, haven't done extensive tests but from trying to respec in multiple places it seems to be in working order.

Mercenary CharGen needs a look however, seems to be bypassing some checks as there's a lack of logs being made.