### PR TITLE
Made buff exclusion search case insensitive

### DIFF
--- a/ToyBox/classes/MainUI/Browser/BuffExclusionEditor.cs
+++ b/ToyBox/classes/MainUI/Browser/BuffExclusionEditor.cs
@@ -96,10 +96,14 @@ namespace ToyBox {
         }
 
         private static void FilterBuffList(string search) {
+            var searchLower = search.ToLowerInvariant();
             var buffList = GetValidBuffsToAdd();
             _searchResults = string.IsNullOrEmpty(_searchString)
                 ? buffList
-                : buffList.Where(b => b.AssetGuidThreadSafe == search || b.GetDisplayName().Contains(search) || b.NameSafe().Contains(search));
+                : buffList.Where(b => 
+                    b.AssetGuidThreadSafe.ToLowerInvariant() == searchLower || 
+                    b.GetDisplayName().ToLowerInvariant().Contains(searchLower) ||
+                    b.NameSafe().ToLowerInvariant().Contains(searchLower));
             _displayedBuffs = GetPaginatedBuffs();
             SetPaginationString();
             //This will clamp down to the range of pages, so if you search while on the last page, for example, it will place you on the max page after the search is executed.


### PR DESCRIPTION
Background: a few months back, I added the ability to exclude certain buffs from the buff duration multiplier. Last night, I noticed there was a debuff multiplier on the army paralyzed debuff, so I decided to add some exclusions. Turns out, I made the search case sensitive and it took me a while to figure out why I couldn't find the buff. This just fixes that problem. 

@ArcaneTrixter, I know you're planning on making a patch soon, so I thought you might want to roll this with that release, but if you'd prefer me to add version/patch notes, I can do that.