### PR TITLE
Fix respeccing Cam, add more ignore requirements options.

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -42,11 +42,13 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***Narria***) Army Editor now lets you edit current mana for a leader
 * (***Narria***) Party Editor: Fixed crasher in changing characters after selecting other spellbook
 * (***Narria***) Enchantment: Fixed issue where the wrong enchantment would be added if you selected weapon enchantments
-* (*** Narria***) Fixed bug where enable achievements with mod active was not working for all achievements or DLC
+* (***Narria***) Fixed bug where enable achievements with mod active was not working for all achievements or DLC
 * (***BuckAMayzing***) The "Fix Alignment" option was causing alignments to not be updated. This is now resolved.
 * (***BuckAMayzing***) Fixed issue with buff multiplier exclusions introduced in Version 1.4.22
 * (***dark0dave***) Support on linux for standard ASCI based glyphs for checkboxes, toggles, etc
 * (***ArcaneTrixter***) Fix bugs reported for merged spellbooks.
+* (***ArcaneTrixter***) Enhancement for Ignore Alignment Requirements to enable divine casters to ignore deity alignments. Looking at you, Camellia!
+* (***ArcaneTrixter***) Adding cheating option to ignore anything at all that would prevent you from using an ability.
 * (***gespenstgaming***) Increased the creation ability point cap to 600.
 ### Ver 1.4.22
 * Updated for Last Sarkorians DLC - Game Version 2.1.0w+

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -493,6 +493,7 @@ namespace ToyBox {
                 () => ToggleCallback("Equipment No Weight", ref settings.toggleEquipmentNoWeight, BagOfPatches.Tweaks.NoWeight_Patch1.Refresh),
                 () => Toggle("Allow Item Use From Inventory During Combat", ref settings.toggleUseItemsDuringCombat),
                 () => Toggle("Ignore Alignment Requirements for Abilities", ref settings.toggleIgnoreAbilityAlignmentRestriction),
+                () => Toggle("Ignore all Requirements for Abilities", ref settings.toggleIgnoreAbilityAnyRestriction),
                 () => Toggle("Ignore Pet Sizes For Mounting", ref settings.toggleMakePetsRidable),
                 () => Toggle("Ride Any Unit As Your Mount", ref settings.toggleRideAnything),
                 () => { }

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -420,6 +420,7 @@ namespace ToyBox {
         public HashSet<string> ignoredPrerequisiteSet = new(); // adding this granularity might be nice
 
         public bool toggleIgnoreAbilityAlignmentRestriction = false;
+        public bool toggleIgnoreAbilityAnyRestriction = false;
         public bool toggleIgnoreAolityCasterCheckers = false;
         public HashSet<string> ignoredAbilityCasterCheckerSet = new();
         public bool toggleIgnoreActivatableAbilityRestrictions = false;


### PR DESCRIPTION
Resolves #749

Enable divine casters to ignore alignment requirements of their deities and added a cheat Ignore ALL Requirements option