### PR TITLE
Make Preview Events work and Ignore Event Solution Restriction independent from Preview Events and Preview Dialogue

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -56,7 +56,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***ArcaneTrixter***) Adding cheating option to ignore anything at all that would prevent you from using an ability.
 * (***gespenstgaming***) Increased the creation ability point cap to 600.
 * (***ADDB***) Added field for army general experience.
-* (***ADDB***) Fixed Preview Event Results and made Ignore Event Solution Restrictions independent from Preview Flags.
+* (***ADDB***) Fixed Preview Event Results and made Ignore Event Solution Restrictions independent from Preview Flags. Added toggle to disable showing restrictions.
 ### Ver 1.4.22
 * Updated for Last Sarkorians DLC - Game Version 2.1.0w+
 * (***ArcaneTrixter***) Fixed actions bars patches being broken by game update.

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -56,6 +56,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***ArcaneTrixter***) Adding cheating option to ignore anything at all that would prevent you from using an ability.
 * (***gespenstgaming***) Increased the creation ability point cap to 600.
 * (***ADDB***) Added field for army general experience.
+* (***ADDB***) Fixed Preview Event Results and made Ignore Event Solution Restrictions independent from Preview Flags.
 ### Ver 1.4.22
 * Updated for Last Sarkorians DLC - Game Version 2.1.0w+
 * (***ArcaneTrixter***) Fixed actions bars patches being broken by game update.

--- a/ToyBox/classes/MainUI/Crusade/EventEditor.cs
+++ b/ToyBox/classes/MainUI/Crusade/EventEditor.cs
@@ -25,6 +25,13 @@ namespace ToyBox.classes.MainUI {
                 () => Toggle("Instant Events", ref settings.toggleInstantEvent),
                 () => Toggle("Ignore Event Solution Restrictions", ref settings.toggleIgnoreEventSolutionRestrictions),
                 () => {
+                    if (settings.toggleIgnoreEventSolutionRestrictions) {
+                        50.space();
+                        Toggle("Stop showing Restrictions", ref settings.toggleHideEventSolutionRestrictions);
+                        25.space();
+                    }
+                },
+                () => {
                     using (VerticalScope()) {
                         if (ks.ActiveEvents.Count == 0)
                             Label("No active events".orange().bold());
@@ -55,49 +62,49 @@ namespace ToyBox.classes.MainUI {
                 //TODO: toggle to ignore specific restrictions
                 () => Toggle("No Decree Resource Costs", ref settings.toggleTaskNoResourcesCost),
                 () => {
-                     using (VerticalScope()) {
-                         
-                         if (ks.ActiveTasks.Count() == 0)
-                            Label("No active decrees".orange().bold());
-                         foreach (var activeTask in ks.ActiveEvents) {
-                             if (activeTask.AssociatedTask != null) {
-                                 Div(0,25);
-                                 var task = activeTask.AssociatedTask;
-                                 using (HorizontalScope()) {
-                                    Label(task.Name.cyan(), 350.width());
-                                     25.space();
-                                     if (task.IsInProgress)
-                                        Label($"Ends in {task.EndsOn - ks.CurrentDay} days", 200.width());
-                                     else {
-                                        ActionButton("Start", () => {
-                                             task.Start();
-                                         }, 200.width());
-                                     }
-                                     25.space();
+                    using (VerticalScope()) {
 
-                                     if (task.IsInProgress) {
+                        if (ks.ActiveTasks.Count() == 0)
+                            Label("No active decrees".orange().bold());
+                        foreach (var activeTask in ks.ActiveEvents) {
+                            if (activeTask.AssociatedTask != null) {
+                                Div(0, 25);
+                                var task = activeTask.AssociatedTask;
+                                using (HorizontalScope()) {
+                                    Label(task.Name.cyan(), 350.width());
+                                    25.space();
+                                    if (task.IsInProgress)
+                                        Label($"Ends in {task.EndsOn - ks.CurrentDay} days", 200.width());
+                                    else {
+                                        ActionButton("Start", () => {
+                                            task.Start();
+                                        }, 200.width());
+                                    }
+                                    25.space();
+
+                                    if (task.IsInProgress) {
                                         ActionButton("Finish", () => {
-                                             task.m_BonusDays = task.Duration;
-                                         }, 120.width());
-                                         if (task.CanCancelStarted) {
+                                            task.m_BonusDays = task.Duration;
+                                        }, 120.width());
+                                        if (task.CanCancelStarted) {
                                             ActionButton("Cancel", () => {
-                                                 task.Cancel();
-                                             }, 120.width());
-                                         }
-                                         else
-                                             123.space();
-                                     }
-                                     else
-                                         249.space();
-                                     25.space();
-                                     var taskBlueprint = task.Event.EventBlueprint as BlueprintKingdomProject;
+                                                task.Cancel();
+                                            }, 120.width());
+                                        }
+                                        else
+                                            123.space();
+                                    }
+                                    else
+                                        249.space();
+                                    25.space();
+                                    var taskBlueprint = task.Event.EventBlueprint as BlueprintKingdomProject;
                                     Label(task.Description.StripHTML().orange() + "\n" + taskBlueprint.MechanicalDescription.ToString().StripHTML().green());
-                                 }
-                             }
-                         }
-                         ks.TimelineManager.UpdateEvents();
-                     }
-                 }
+                                }
+                            }
+                        }
+                        ks.TimelineManager.UpdateEvents();
+                    }
+                }
              );
 
         }

--- a/ToyBox/classes/MainUI/Crusade/EventEditor.cs
+++ b/ToyBox/classes/MainUI/Crusade/EventEditor.cs
@@ -25,11 +25,9 @@ namespace ToyBox.classes.MainUI {
                 () => Toggle("Instant Events", ref settings.toggleInstantEvent),
                 () => Toggle("Ignore Event Solution Restrictions", ref settings.toggleIgnoreEventSolutionRestrictions),
                 () => {
-                    if (settings.toggleIgnoreEventSolutionRestrictions) {
-                        50.space();
-                        Toggle("Stop showing Restrictions", ref settings.toggleHideEventSolutionRestrictions);
-                        25.space();
-                    }
+                    Toggle("Stop Showing Restrictions", ref settings.toggleHideEventSolutionRestrictions, Width(350));
+                    Space(25);
+                    Label("Only useful if using Preview Events or Ignore Restrictions".green());
                 },
                 () => {
                     using (VerticalScope()) {

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -60,7 +60,7 @@ namespace ToyBox {
             if (cachedPerSave == null) {
                 Mod.Warn("per save settings not found, creating new...");
                 cachedPerSave = new PerSaveSettings {
-                };   
+                };
                 SavePerSaveSettings();
             }
         }
@@ -92,7 +92,7 @@ namespace ToyBox {
                 Mod.Error(e);
             }
         }
-        public PerSaveSettings perSave{
+        public PerSaveSettings perSave {
             get {
                 if (cachedPerSave != null) return cachedPerSave;
                 ReloadPerSaveSettings();
@@ -224,6 +224,7 @@ namespace ToyBox {
         public float enemyLeaderPowerMultiplier = 1;
         public float kingdomTaskResolutionLengthMultiplier = 0;
         public bool toggleIgnoreEventSolutionRestrictions = false;
+        public bool toggleHideEventSolutionRestrictions = false;
         public int unitCount = 100;
 
         // Settlement

--- a/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
+++ b/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
@@ -402,7 +402,7 @@ namespace ToyBox {
                 var isAvail = eventSolution.IsAvail || settings.toggleIgnoreEventSolutionRestrictions;
                 var color = eventSolution.IsAvail ? "#005800><b>" : "#800000>";
                 if (showResults || !settings.toggleHideEventSolutionRestrictions) {
-                    if (eventSolution.m_AvailConditions.HasConditions) {
+                    if (eventSolution.m_AvailConditions.HasConditions && !settings.toggleHideEventSolutionRestrictions) {
                         if (settings.toggleIgnoreEventSolutionRestrictions && !eventSolution.IsAvail)
                             extraText += $"\n<color=#005800><b>[Overridden]:</b></color> ";
                         else

--- a/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
+++ b/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
@@ -401,10 +401,10 @@ namespace ToyBox {
                 var extraText = "";
                 var isAvail = eventSolution.IsAvail || settings.toggleIgnoreEventSolutionRestrictions;
                 var color = isAvail ? "#005800><b>" : "#800000>";
-                if (showResults) {
+                if (showResults || !settings.toggleHideEventSolutionRestrictions) {
                     if (eventSolution.m_AvailConditions.HasConditions)
                         extraText += $"\n<color={color}[{string.Join(", ", eventSolution.m_AvailConditions.Conditions.Select(c => c.GetCaption())).MergeSpaces(true)}]</b></color>";
-                    if (eventSolution.m_SuccessEffects.Actions.Length > 0)
+                    if (eventSolution.m_SuccessEffects.Actions.Length > 0 && showResults)
                         extraText += $"\n[{string.Join(", ", eventSolution.m_SuccessEffects.Actions.Select(c => c.GetCaption())).MergeSpaces(true)}]";
                 }
                 if (isAvail) {

--- a/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
+++ b/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
@@ -391,7 +391,8 @@ namespace ToyBox {
                                         bool isOn = false) {
                 // Should it be previewEventResults here?
                 // Or previewDialogResults && previewEventResults
-                if (!settings.previewDialogResults) return true;
+                bool showResults = settings.previewDialogResults || settings.previewEventResults;
+                if (!showResults && !settings.toggleIgnoreEventSolutionRestrictions) return true;
                 __instance.gameObject.SetActive(true);
                 __instance.EventSolution = eventSolution;
                 __instance.Toggle.group = toggleGroup;
@@ -400,10 +401,12 @@ namespace ToyBox {
                 var extraText = "";
                 var isAvail = eventSolution.IsAvail || settings.toggleIgnoreEventSolutionRestrictions;
                 var color = isAvail ? "#005800><b>" : "#800000>";
-                if (eventSolution.m_AvailConditions.HasConditions)
-                    extraText += $"\n<color={color}[{string.Join(", ", eventSolution.m_AvailConditions.Conditions.Select(c => c.GetCaption())).MergeSpaces(true)}]</b></color>";
-                if (eventSolution.m_SuccessEffects.Actions.Length > 0)
-                    extraText += $"\n[{string.Join(", ", eventSolution.m_SuccessEffects.Actions.Select(c => c.GetCaption())).MergeSpaces(true)}]";
+                if (showResults) {
+                    if (eventSolution.m_AvailConditions.HasConditions)
+                        extraText += $"\n<color={color}[{string.Join(", ", eventSolution.m_AvailConditions.Conditions.Select(c => c.GetCaption())).MergeSpaces(true)}]</b></color>";
+                    if (eventSolution.m_SuccessEffects.Actions.Length > 0)
+                        extraText += $"\n[{string.Join(", ", eventSolution.m_SuccessEffects.Actions.Select(c => c.GetCaption())).MergeSpaces(true)}]";
+                }
                 if (isAvail) {
                     if (extraText.Length > 0)
                         __instance.m_TextLabel.text = $"{eventSolution.SolutionText}<size=75%>{extraText}</size>";
@@ -433,7 +436,7 @@ namespace ToyBox {
                 var item = addIntermediateItemAct.ItemToGive;
                 if (item != null) {
                     var pattern = @"<link=([^>]*)>";
-                    var matches = Regex.Matches(result, pattern);                    
+                    var matches = Regex.Matches(result, pattern);
                     if (matches.Cast<Match>().FirstOrDefault()?
                         .Groups.Cast<Group>().FirstOrDefault()?
                         .Captures.Cast<Capture>().FirstOrDefault()?
@@ -495,13 +498,13 @@ namespace ToyBox {
                         if (relicProject.TriggerCondition.HasConditions &&
                             relicProject.TriggerCondition.Conditions.First() is FlagUnlocked unlockedFlag) {
                             var conditionFlag = unlockedFlag.ConditionFlag;
-                            if (blueprint.ElementsArray.Exists(elem 
+                            if (blueprint.ElementsArray.Exists(elem
                                     => elem is KingdomActionStartEvent actE
-                                       && actE.Event.ElementsArray.Exists(elem2 
+                                       && actE.Event.ElementsArray.Exists(elem2
                                            => elem2 is UnlockFlag unlockFlag
                                            && unlockFlag.flag == conditionFlag
                                            )
-                                       ) 
+                                       )
                                      && relicProject.ElementsArray.Find(elem => elem is KingdomActionStartEvent) is KingdomActionStartEvent subActionEvent
                                      && subActionEvent.Event is BlueprintCrusadeEvent subBp
                                      && subBp.EventSolutions.Length >= 1

--- a/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
+++ b/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
@@ -400,10 +400,15 @@ namespace ToyBox {
                 __instance.Toggle.onValueChanged.AddListener(onToggle);
                 var extraText = "";
                 var isAvail = eventSolution.IsAvail || settings.toggleIgnoreEventSolutionRestrictions;
-                var color = isAvail ? "#005800><b>" : "#800000>";
+                var color = eventSolution.IsAvail ? "#005800><b>" : "#800000>";
                 if (showResults || !settings.toggleHideEventSolutionRestrictions) {
-                    if (eventSolution.m_AvailConditions.HasConditions)
-                        extraText += $"\n<color={color}[{string.Join(", ", eventSolution.m_AvailConditions.Conditions.Select(c => c.GetCaption())).MergeSpaces(true)}]</b></color>";
+                    if (eventSolution.m_AvailConditions.HasConditions) {
+                        if (settings.toggleIgnoreEventSolutionRestrictions && !eventSolution.IsAvail)
+                            extraText += $"\n<color=#005800><b>[Overridden]:</b></color> ";
+                        else
+                            extraText += $"\n";
+                        extraText += $"<color={color}[{string.Join(", ", eventSolution.m_AvailConditions.Conditions.Select(c => c.GetCaption())).MergeSpaces(true)}]</b></color>";
+                    }
                     if (eventSolution.m_SuccessEffects.Actions.Length > 0 && showResults)
                         extraText += $"\n[{string.Join(", ", eventSolution.m_SuccessEffects.Actions.Select(c => c.GetCaption())).MergeSpaces(true)}]";
                 }


### PR DESCRIPTION
Resolves #772.
Before, the Preview Events flag was useless. It also wasn't possible to activate the Ignore Event Solution Restriction flag without also showing the results (because Preview Dialogue Result needed to be activated).
I removed that dependency and fixed the Preview Events flag.