### PR TITLE
Buff duration 2

### DIFF
--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Multipliers.cs
@@ -197,7 +197,7 @@ namespace ToyBox.BagOfPatches {
 
         private static TimeSpan GetNewBuffDuration(TimeSpan originalDuration) {
             var ticks = originalDuration.Ticks;
-            var checkValue = (long)(long.MaxValue / settings.buffDurationMultiplierValue);
+            var checkValue = (double)(long.MaxValue / settings.buffDurationMultiplierValue);
             long adjusted;
             if (ticks > checkValue) { // ticks * multipler > max -> return max
                 adjusted = long.MaxValue;


### PR DESCRIPTION
Fixed the overflow issue previously; multipliers below 1 caused underflow and permanent buffs.
Resolves #775 