### PR TITLE
Fix for Decree Preview carryover to Event Window

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -58,6 +58,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***gespenstgaming***) Increased the creation ability point cap to 600.
 * (***ADDB***) Added field for army general experience.
 * (***ADDB***) Fixed Preview Event Results and made Ignore Event Solution Restrictions independent from Preview Flags. Added toggle to disable showing restrictions.
+* (***ADDB***) Fixed a bug where activation Decree Preview would still show when opening an Event Window after opening a Decree.
 ### Ver 1.4.22
 * Updated for Last Sarkorians DLC - Game Version 2.1.0w+
 * (***ArcaneTrixter***) Fixed actions bars patches being broken by game update.

--- a/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
+++ b/ToyBox/classes/MonkeyPatchin/PreviewManager.cs
@@ -389,8 +389,7 @@ namespace ToyBox {
                                         UnityAction<bool> onToggle,
                                         ToggleGroup toggleGroup,
                                         bool isOn = false) {
-                // Should it be previewEventResults here?
-                // Or previewDialogResults && previewEventResults
+
                 bool showResults = settings.previewDialogResults || settings.previewEventResults;
                 if (!showResults && !settings.toggleIgnoreEventSolutionRestrictions) return true;
                 bool showRestrictions = (settings.toggleIgnoreEventSolutionRestrictions || settings.previewDialogResults) && !settings.toggleHideEventSolutionRestrictionsPreview;
@@ -470,7 +469,6 @@ namespace ToyBox {
                         var currentEventSolution2 = __instance.m_Footer.CurrentEventSolution;
                         resultDescription.text = ((currentEventSolution2 != null) ? currentEventSolution2.ResultText : null);
                         __instance.m_Disposables.Add(__instance.m_ResultDescription.SetLinkTooltip(null, null, default(TooltipConfig)));
-
                     }
                     else
                         __instance.m_ResultDescription.text = string.Empty;
@@ -553,6 +551,13 @@ namespace ToyBox {
                 __instance.m_Disposables.Add(__instance.m_MechanicalDescription.SetLinkTooltip(null, null, default));
 
                 return false;
+            }
+        }
+
+        [HarmonyPatch(typeof(KingdomUIEventWindow), nameof(KingdomUIEventWindow.OnClose))]
+        private static class KingdomUIEventWindow_OnClose_Patch {
+            private static void Prefix(KingdomUIEventWindow __instance) {
+                __instance.m_MechanicalDescription.text = null;
             }
         }
 


### PR DESCRIPTION
Added onClose() patch which resets description text; seems to fix the issue.
Resolves #770 