### PR TITLE
Removed Button text overflow

### DIFF
--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -535,7 +535,7 @@ namespace ToyBox {
                 () => LogSlider("All Experience", ref settings.experienceMultiplier, 0f, 20, 1, 1, "", AutoWidth()),
                 () => {
                     using (HorizontalScope()) {
-                        Toggle("Override Experience Multiplier for Combat", ref settings.useCombatExpSlider, Width(275));
+                        Toggle("Override for Combat", ref settings.useCombatExpSlider, Width(275));
                         if (settings.useCombatExpSlider) {
                             Space(10);
                             LogSlider("", ref settings.experienceMultiplierCombat, 0f, 20, 1, 1, "", AutoWidth());
@@ -544,7 +544,7 @@ namespace ToyBox {
                 },
                 () => {
                     using (HorizontalScope()) {
-                        Toggle("Override Experience Multiplier for Quests", ref settings.useQuestsExpSlider, Width(275));
+                        Toggle("Override for Quests", ref settings.useQuestsExpSlider, Width(275));
                         if (settings.useQuestsExpSlider) {
                             Space(10);
                             LogSlider("", ref settings.experienceMultiplierQuests, 0f, 20, 1, 1, "", AutoWidth());
@@ -553,7 +553,7 @@ namespace ToyBox {
                 },
                 () => {
                     using (HorizontalScope()) {
-                        Toggle("Override Experience Multiplier for Skill Checks", ref settings.useSkillChecksExpSlider, Width(275));
+                        Toggle("Override for Skill Checks", ref settings.useSkillChecksExpSlider, Width(275));
                         if (settings.useSkillChecksExpSlider) {
                             Space(10);
                             LogSlider("", ref settings.experienceMultiplierSkillChecks, 0f, 20, 1, 1, "", AutoWidth());
@@ -562,7 +562,7 @@ namespace ToyBox {
                 },
                 () => {
                     using (HorizontalScope()) {
-                        Toggle("Override Experience Multiplier for Traps Experience", ref settings.useTrapsExpSlider, Width(275));
+                        Toggle("Override for Traps", ref settings.useTrapsExpSlider, Width(275));
                         if (settings.useTrapsExpSlider) {
                             Space(10);
                             LogSlider("", ref settings.experienceMultiplierTraps, 0f, 20, 1, 1, "", AutoWidth());

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -535,7 +535,7 @@ namespace ToyBox {
                 () => LogSlider("All Experience", ref settings.experienceMultiplier, 0f, 20, 1, 1, "", AutoWidth()),
                 () => {
                     using (HorizontalScope()) {
-                        Toggle("Override for Combat", ref settings.useCombatExpSlider, Width(275));
+                        Toggle("Override Experience Multiplier for Combat", ref settings.useCombatExpSlider, Width(275));
                         if (settings.useCombatExpSlider) {
                             Space(10);
                             LogSlider("", ref settings.experienceMultiplierCombat, 0f, 20, 1, 1, "", AutoWidth());
@@ -544,7 +544,7 @@ namespace ToyBox {
                 },
                 () => {
                     using (HorizontalScope()) {
-                        Toggle("Override for Quests", ref settings.useQuestsExpSlider, Width(275));
+                        Toggle("Override Experience Multiplier for Quests", ref settings.useQuestsExpSlider, Width(275));
                         if (settings.useQuestsExpSlider) {
                             Space(10);
                             LogSlider("", ref settings.experienceMultiplierQuests, 0f, 20, 1, 1, "", AutoWidth());
@@ -553,7 +553,7 @@ namespace ToyBox {
                 },
                 () => {
                     using (HorizontalScope()) {
-                        Toggle("Override for Skill Checks", ref settings.useSkillChecksExpSlider, Width(275));
+                        Toggle("Override Experience Multiplier for Skill Checks", ref settings.useSkillChecksExpSlider, Width(275));
                         if (settings.useSkillChecksExpSlider) {
                             Space(10);
                             LogSlider("", ref settings.experienceMultiplierSkillChecks, 0f, 20, 1, 1, "", AutoWidth());
@@ -562,7 +562,7 @@ namespace ToyBox {
                 },
                 () => {
                     using (HorizontalScope()) {
-                        Toggle("Override for Traps", ref settings.useTrapsExpSlider, Width(275));
+                        Toggle("Override Experience Multiplier for Traps Experience", ref settings.useTrapsExpSlider, Width(275));
                         if (settings.useTrapsExpSlider) {
                             Space(10);
                             LogSlider("", ref settings.experienceMultiplierTraps, 0f, 20, 1, 1, "", AutoWidth());

--- a/ToyBox/classes/MainUI/PartyEditor/ClassesEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/ClassesEditor.cs
@@ -92,16 +92,12 @@ namespace ToyBox {
                         IntTextField(ref tmpExp, null, Width(150f));
                         prog.Experience = tmpExp;
                     }
-                }
-                using (HorizontalScope()) {
-                    using (HorizontalScope(Width(781))) {
-                        Space(100);
-                        ActionButton("Adjust based on Level", () => {
-                            prog.MythicExperience = prog.MythicLevel;
-                        }, AutoWidth());
-                        Space(27);
-                    }
-                    Label("This sets your experience to match the current value of character level".green());
+                    ActionButton("Adjust based on Level", () => {
+                        var newXP = prog.ExperienceTable.GetBonus(Mathf.RoundToInt(prog.CharacterLevel));
+                        prog.Experience = newXP;
+                    }, Width(150));
+                    Space(27);
+                    Label("This sets your experience to match the current value of character level.".green());
                 }
                 Div(100, 25);
                 using (HorizontalScope()) {
@@ -130,15 +126,10 @@ namespace ToyBox {
                             prog.MythicExperience = tmpMythicExp / 10;
                         }
                     }
-                }
-                using (HorizontalScope()) {
-                    using (HorizontalScope(Width(781))) {
-                        Space(100);
-                        ActionButton("Adjust based on Level", () => {
-                            prog.MythicExperience = prog.MythicLevel;
-                        }, AutoWidth());
-                        Space(27);
-                    }
+                    ActionButton("Adjust based on Level", () => {
+                        prog.MythicExperience = prog.MythicLevel;
+                    }, Width(150));
+                    Space(27);
                     Label("This sets your mythic experience to match the current value of mythic level. Note that mythic experience is 1 point per level".green());
                 }
                 var classCount = classData.Count(x => !x.CharacterClass.IsMythic);

--- a/ToyBox/classes/MainUI/PartyEditor/ClassesEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/ClassesEditor.cs
@@ -92,12 +92,16 @@ namespace ToyBox {
                         IntTextField(ref tmpExp, null, Width(150f));
                         prog.Experience = tmpExp;
                     }
-                    ActionButton("Adjust based on Level", () => {
-                        var newXP = prog.ExperienceTable.GetBonus(Mathf.RoundToInt(prog.CharacterLevel));
-                        prog.Experience = newXP;
-                    }, Width(150));
-                    Space(27);
-                    Label("This sets your experience to match the current value of character level.".green());
+                }
+                using (HorizontalScope()) {
+                    using (HorizontalScope(Width(781))) {
+                        Space(100);
+                        ActionButton("Adjust based on Level", () => {
+                            prog.MythicExperience = prog.MythicLevel;
+                        }, AutoWidth());
+                        Space(27);
+                    }
+                    Label("This sets your experience to match the current value of character level".green());
                 }
                 Div(100, 25);
                 using (HorizontalScope()) {
@@ -126,10 +130,15 @@ namespace ToyBox {
                             prog.MythicExperience = tmpMythicExp / 10;
                         }
                     }
-                    ActionButton("Adjust based on Level", () => {
-                        prog.MythicExperience = prog.MythicLevel;
-                    }, Width(150));
-                    Space(27);
+                }
+                using (HorizontalScope()) {
+                    using (HorizontalScope(Width(781))) {
+                        Space(100);
+                        ActionButton("Adjust based on Level", () => {
+                            prog.MythicExperience = prog.MythicLevel;
+                        }, AutoWidth());
+                        Space(27);
+                    }
                     Label("This sets your mythic experience to match the current value of mythic level. Note that mythic experience is 1 point per level".green());
                 }
                 var classCount = classData.Count(x => !x.CharacterClass.IsMythic);


### PR DESCRIPTION
Fixed text overflow in buttons I changed in the modifiable character experience commit when using UI scaling

This:
https://cdn.discordapp.com/attachments/815735034514112512/1089699196233338890/2023-03-26_19_55_19-Pathfinder_Wrath_Of_The_Righteous.png

to this:

https://cdn.discordapp.com/attachments/815735034514112512/1089706119359889438/image.png