### PR TITLE
Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set very high

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -38,7 +38,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * **Quest Resolution**: this allows you to view your active quests and advance them as needed to work around bugs or skip quests you don't want to do.  Be warned this may break your game progression if used carelessly.
 
 ### Ver 1.4.25 (coming soon)
-* (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to interact when buff duration multiplier was set to a very high number
+* (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
 
 ### Ver 1.4.24
 * (***Narria***) Loot coloring improvents

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -37,7 +37,10 @@ Enchantment: allows you to add or remove enchantments from the items in your inv
 WARNING: this tool can both miraculously fix your broken progression or it can break it even further. Save and back up your save before using. Remember that "with great power comes great responsibility"
 * **Quest Resolution**: this allows you to view your active quests and advance them as needed to work around bugs or skip quests you don't want to do.  Be warned this may break your game progression if used carelessly.
 
-### Ver 1.4.24 (coming soon)
+### Ver 1.4.25 (coming soon)
+* (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to interact when buff duration multiplier was set to a very high number
+
+### Ver 1.4.24
 * (***Narria***) Loot coloring improvents
   * Added rarity tags when color loot items is active
   * Added new alternative to just color the rarity tags and show titles in black text

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -37,10 +37,7 @@ Enchantment: allows you to add or remove enchantments from the items in your inv
 WARNING: this tool can both miraculously fix your broken progression or it can break it even further. Save and back up your save before using. Remember that "with great power comes great responsibility"
 * **Quest Resolution**: this allows you to view your active quests and advance them as needed to work around bugs or skip quests you don't want to do.  Be warned this may break your game progression if used carelessly.
 
-### Ver 1.4.25 (coming soon)
-* (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
-
-### Ver 1.4.24
+### Ver 1.4.24 (coming soon)
 * (***Narria***) Loot coloring improvents
   * Added rarity tags when color loot items is active
   * Added new alternative to just color the rarity tags and show titles in black text
@@ -68,6 +65,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***Narria***) Added Brains, AIActions and Considerations to Search 'n Pick
 * (***Narria***) Fixed crasher during character creaton on the loot screen
 * (***ADDB***) (Experimental) Added a feature that allows hiding map loot pins on the map if the contained loot doesn't reach at least a selected rarity.
+* (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
 ### Ver 1.4.23
 * (***Narria***) Party Editor is faster for browsing existing features/spells/etc - Blueprints don't load until you select Show All
 * (***Narria***) Deferred Blueprint loading for Armies as well

--- a/ToyBox/classes/Infrastructure/SettingsDefaults.cs
+++ b/ToyBox/classes/Infrastructure/SettingsDefaults.cs
@@ -7,6 +7,8 @@ namespace ToyBox {
             "e6f2fc5d73d88064583cb828801212f4", //Fatigued
             "bb1b849f30e6464284c1efd0e812d626", //Army Nauseated
             "f59aa0658cda4c7b82bf73c632a39650", //Army Stinking Cloud 
+            "6179bbe7a7b4b674c813dedbca121799", //Summoned Unit Appear Buff (causes inaction for summoned units)
+            "12f2f2cf326dfd743b2cce5b14e99b3c", //Resurrection Buff
         };
     }
 }


### PR DESCRIPTION
Should resolve #788 and #471