### PR TITLE
Added FoW Multiplier

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -65,6 +65,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***Narria***) Added Brains, AIActions and Considerations to Search 'n Pick
 * (***Narria***) Fixed crasher during character creaton on the loot screen
 * (***ADDB***) (Experimental) Added a feature that allows hiding map loot pins on the map if the contained loot doesn't reach at least a selected rarity.
+* (***ADDB***) Added Fog of War Radius multiplier.
 * (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
 ### Ver 1.4.23
 * (***Narria***) Party Editor is faster for browsing existing features/spells/etc - Blueprints don't load until you select Show All

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -7,15 +7,15 @@ using Kingmaker.Cheats;
 using Kingmaker.Kingdom;
 using Kingmaker.PubSubSystem;
 using Kingmaker.UnitLogic;
-using Kingmaker.UnitLogic.Alignments;
-using Kingmaker.UI.Dialog;
-using Kingmaker.Utility;
 using ModKit;
 using ToyBox;
 using UnityEngine;
 using UnityModManagerNet;
 using static ModKit.UI;
-using static ToyBox.BagOfPatches.PartyView;
+using Kingmaker.Controllers;
+using Kingmaker.View;
+using Kingmaker.EntitySystem.Entities;
+using System.Collections.Generic;
 
 namespace ToyBox {
     public static class BagOfTricks {
@@ -572,6 +572,24 @@ namespace ToyBox {
                 );
             Div(0, 25);
             HStack("Other Multipliers", 1,
+                () => {
+                    LogSlider("Fog of War Range", ref settings.fowMultiplier, 0f, 100f, 1, 1, "", AutoWidth());
+                    List<UnitEntityData> units = Game.Instance.Player.m_PartyAndPets;
+                    foreach (var unit in units) {
+                        FogOfWarController.VisionRadiusMultiplier = settings.fowMultiplier;
+                        FogOfWarRevealerSettings revealer = unit.View.FogOfWarRevealer;
+                        if (settings.fowMultiplier == 1) {
+                            revealer.DefaultRadius = true;
+                            revealer.UseDefaultFowBorder = true;
+                            revealer.Radius = 1.0f;
+                        }
+                        else {
+                            revealer.DefaultRadius = false;
+                            revealer.UseDefaultFowBorder = false;
+                            revealer.Radius = FogOfWarController.VisionRadius * settings.fowMultiplier;
+                        }
+                    }
+                },
                 () => LogSlider("Money Earned", ref settings.moneyMultiplier, 0f, 20, 1, 1, "", AutoWidth()),
                 () => LogSlider("Vendor Sell Price", ref settings.vendorSellPriceMultiplier, 0f, 20, 1, 1, "", AutoWidth()),
                 () => LogSlider("Vendor Buy Price", ref settings.vendorBuyPriceMultiplier, 0f, 20, 1, 1, "", AutoWidth()),

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -283,6 +283,7 @@ namespace ToyBox {
         public bool useQuestsExpSlider = false;
         public bool useSkillChecksExpSlider = false;
         public bool useTrapsExpSlider = false;
+        public float fowMultiplier = 1;
         public float moneyMultiplier = 1;
         public float vendorSellPriceMultiplier = 1;
         public float vendorBuyPriceMultiplier = 1;


### PR DESCRIPTION
Closes #796 

1.0 (default):
![grafik](https://user-images.githubusercontent.com/62178123/229387958-e389f8bb-1aed-4a64-9ef2-02f182fa9ca7.png)
2.0:
![grafik](https://user-images.githubusercontent.com/62178123/229388015-2e0b2252-e1c6-4eb0-983c-35aa37b3716b.png)

Note: While I ran around a bit, I (obviously) haven't done any excessive testing. I assume that raising this significantly might lead to performance issues because more objects will be rendered. I however do not know how (un-)noticable this effect will be.