### PR TITLE
Add Alignment Shifting Buttons

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -64,11 +64,13 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***Narria***) Added temporary AI category to Party view.  Right now you can see what AI actions/considerations are active on a units breain. This is the beginning of an improved AI/Gambits feature which will be in its own top level tab
 * (***Narria***) Added Brains, AIActions and Considerations to Search 'n Pick
 * (***Narria***) Fixed crasher during character creaton on the loot screen
+* (***Narria***) Fixed issue where the arrow key Y scrolling becomes inverted when tilt the camera higher than like 45 or 60 degrees
 * (***ADDB***) (Experimental) Added a feature that allows hiding map loot pins on the map if the contained loot doesn't reach at least a selected rarity.
 * (***ADDB***) Added Kill on Engage toggle (Which kills a unit as soon as it joins a fight against Character).
 * (***ADDB***) Added Fog of War Radius multiplier.
 * (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
 * (***CascadingDragon***) Moved "Disallow Companions" back to Dialog section
+* (***CascadingDragon***) Added options to add points to Alignment
 ### Ver 1.4.23
 * (***Narria***) Party Editor is faster for browsing existing features/spells/etc - Blueprints don't load until you select Show All
 * (***Narria***) Deferred Blueprint loading for Armies as well

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -68,6 +68,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***ADDB***) Added Kill on Engage toggle (Which kills a unit as soon as it joins a fight against Character).
 * (***ADDB***) Added Fog of War Radius multiplier.
 * (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
+* (***CascadingDragon***) 
 ### Ver 1.4.23
 * (***Narria***) Party Editor is faster for browsing existing features/spells/etc - Blueprints don't load until you select Show All
 * (***Narria***) Deferred Blueprint loading for Armies as well

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -68,7 +68,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***ADDB***) Added Kill on Engage toggle (Which kills a unit as soon as it joins a fight against Character).
 * (***ADDB***) Added Fog of War Radius multiplier.
 * (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
-* (***CascadingDragon***) 
+* (***CascadingDragon***) Moved "Disallow Companions" back to Dialog section
 ### Ver 1.4.23
 * (***Narria***) Party Editor is faster for browsing existing features/spells/etc - Blueprints don't load until you select Show All
 * (***Narria***) Deferred Blueprint loading for Armies as well

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -219,7 +219,7 @@ namespace ToyBox {
                     Label("Experimental ".orange() + " your friends forgive even your most vile choices.".green());
                 },   
                 () => {
-                    Toggle("Disallow Companions Leaving Party", ref settings.toggleBlockUnrecruit, 300.width());
+                    Toggle("Disallow Companions Leaving Party", ref settings.toggleBlockUnrecruit);
                     25.space();
                     Label("Warning: ".color(RGBA.red) + " Only use when Friendship is Magic doesn't work, and then turn off immediately after. Can  otherwise break your save".orange());
                 },

--- a/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
@@ -22,6 +22,8 @@ using Kingmaker.UnitLogic.Parts;
 
 namespace ToyBox {
     public partial class PartyEditor {
+        public static Kingmaker.UnitLogic.Alignments.IAlignmentShiftProvider ToyboxAlignmentProvider { get; private set; } //Will remember to set custom description... Eventually
+
         public static void OnStatsGUI(UnitEntityData ch) {
             Div(100, 20, 755);
             var alignment = ch.Descriptor.Alignment.ValueRaw;
@@ -51,6 +53,21 @@ namespace ToyBox {
                 if (SelectionGrid(ref maskIndex, titles, 3, Width(800))) {
                     ch.Descriptor.Alignment.LockAlignment(AlignmentMasks[maskIndex], new Alignment?());
                 }
+            }
+            Div(100, 20, 755);
+            using (HorizontalScope()) {
+                Space(100);
+                Label("Alignment Value", AutoWidth());
+                Space(25);
+                var increment = IntTextField(ref settings.increment, null, Width(55));
+                Space(150);
+                ActionButton($"Add {increment}" + " Law".cyan(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Lawful, increment, ToyboxAlignmentProvider), AutoWidth());
+                Space(10);
+                ActionButton($"Add {increment}" + " Chaos".pink(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Chaotic, increment, ToyboxAlignmentProvider), AutoWidth());
+                Space(10);
+                ActionButton($"Add {increment}" + " Good".green(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Good, increment, ToyboxAlignmentProvider), AutoWidth());
+                Space(10);
+                ActionButton($"Add {increment}" + " Evil".red(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Evil, increment, ToyboxAlignmentProvider), AutoWidth());
             }
             Div(100, 20, 755);
             using (HorizontalScope()) {


### PR DESCRIPTION
So yeah, uh, definitely went wrong somewhere with commit history, but ignoring that,  a quick and dirty implementation of buttons that add points to specific alignment. Feel free to make it less ugly.
Also think I updated the README correctly?