### PR TITLE
Added Visual Character Size Multiplier.

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -36,7 +36,7 @@ Enchantment: allows you to add or remove enchantments from the items in your inv
 * **Etudes**: this is a new and exciting feature that allows you to see for the first time the structure and some basic relationships of Etudes and other Elements that control the progression of your game story. Etudes are hierarchical in structure and additionally contain a set of Elements that can both conditions to check and actions to execute when the etude is started. As you browe you will notice there is a disclosure triangle next to the name which will show the children of the Etude.  Etudes that have Elements will offer a second disclosure triangle next to the status that will show them to you.
 WARNING: this tool can both miraculously fix your broken progression or it can break it even further. Save and back up your save before using. Remember that "with great power comes great responsibility"
 * **Quest Resolution**: this allows you to view your active quests and advance them as needed to work around bugs or skip quests you don't want to do.  Be warned this may break your game progression if used carelessly.
-### Ver 1.4.25
+### Ver 1.4.25 (coming soon)
 * (***ADDB***) Added Visual Character Size Multiplier.
 ### Ver 1.4.24
 * (***Narria***) Loot coloring improvents

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -36,6 +36,8 @@ Enchantment: allows you to add or remove enchantments from the items in your inv
 * **Etudes**: this is a new and exciting feature that allows you to see for the first time the structure and some basic relationships of Etudes and other Elements that control the progression of your game story. Etudes are hierarchical in structure and additionally contain a set of Elements that can both conditions to check and actions to execute when the etude is started. As you browe you will notice there is a disclosure triangle next to the name which will show the children of the Etude.  Etudes that have Elements will offer a second disclosure triangle next to the status that will show them to you.
 WARNING: this tool can both miraculously fix your broken progression or it can break it even further. Save and back up your save before using. Remember that "with great power comes great responsibility"
 * **Quest Resolution**: this allows you to view your active quests and advance them as needed to work around bugs or skip quests you don't want to do.  Be warned this may break your game progression if used carelessly.
+### Ver 1.4.25
+* (***ADDB***) Added Visual Character Size Multiplier.
 ### Ver 1.4.24
 * (***Narria***) Loot coloring improvents
   * Added rarity tags when color loot items is active

--- a/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
@@ -91,9 +91,9 @@ namespace ToyBox {
             using (HorizontalScope()) {
                 if (ch != null && ch.HashKey() != null) {
                     Space(100);
-                    var scaleMult = Main.settings.perSave.scaleVisualModelSettings.GetValueOrDefault(ch.HashKey(), 1.0f);
+                    var scaleMult = Main.settings.perSave.characterModelSizeMultiplier.GetValueOrDefault(ch.HashKey(), 1.0f);
                     if (LogSliderCustomLabelWidth("Visual Character Size Multiplier", ref scaleMult, 0.01f, 40f, 1, 2, "", 400, AutoWidth())) {
-                        Main.settings.perSave.scaleVisualModelSettings[ch.HashKey()] = scaleMult;
+                        Main.settings.perSave.characterModelSizeMultiplier[ch.HashKey()] = scaleMult;
                         Settings.SavePerSaveSettings();
                     }
                     if (scaleMult != ch.View.gameObject.transform.localScale[0]) {

--- a/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
@@ -88,6 +88,19 @@ namespace ToyBox {
                 Space(528);
                 ActionButton("Reset", () => { ch.Descriptor.State.Size = ch.Descriptor.OriginalSize; }, Width(197));
             }
+            using (HorizontalScope()) {
+                if (ch != null && ch.HashKey() != null) {
+                    Space(100);
+                    var scaleMult = Main.settings.perSave.scaleVisualModelSettings.GetValueOrDefault(ch.HashKey(), 1.0f);
+                    if (LogSliderCustomLabelWidth("Visual Character Size Multiplier", ref scaleMult, 0.01f, 40f, 1, 2, "", 400, AutoWidth())) {
+                        Main.settings.perSave.scaleVisualModelSettings[ch.HashKey()] = scaleMult;
+                        Settings.SavePerSaveSettings();
+                    }
+                    if (scaleMult != ch.View.gameObject.transform.localScale[0]) {
+                        ch.View.gameObject.transform.localScale = new Vector3(scaleMult, scaleMult, scaleMult);
+                    }
+                }
+            }
             Div(100, 20, 755);
             using (HorizontalScope()) {
                 Space(100);

--- a/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
@@ -91,13 +91,11 @@ namespace ToyBox {
             using (HorizontalScope()) {
                 if (ch != null && ch.HashKey() != null) {
                     Space(100);
-                    var scaleMult = Main.settings.perSave.characterModelSizeMultiplier.GetValueOrDefault(ch.HashKey(), 1.0f);
-                    if (LogSliderCustomLabelWidth("Visual Character Size Multiplier", ref scaleMult, 0.01f, 40f, 1, 2, "", 400, AutoWidth())) {
+                    var scaleMult = ch.View.gameObject.transform.localScale[0];
+                    if (LogSliderCustomLabelWidth("Visual Character Size Multiplier".color(RGBA.none) + " (This setting is per-save)", ref scaleMult, 0.01f, 40f, 1, 2, "", 400, AutoWidth())) {
                         Main.settings.perSave.characterModelSizeMultiplier[ch.HashKey()] = scaleMult;
-                        Settings.SavePerSaveSettings();
-                    }
-                    if (scaleMult != ch.View.gameObject.transform.localScale[0]) {
                         ch.View.gameObject.transform.localScale = new Vector3(scaleMult, scaleMult, scaleMult);
+                        Settings.SavePerSaveSettings();
                     }
                 }
             }

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -34,6 +34,10 @@ namespace ToyBox {
         [JsonProperty]
         public Dictionary<string, HashSet<string>> excludeClassesFromCharLevelSets = new();
 
+        // This is the scaling modifier which is applied to the visual model of each character
+        [JsonProperty]
+        public Dictionary<string, float> scaleVisualModelSettings = new();
+
         // Dictionary of Name/IsLegendaryHero for configuration per party member
         [JsonProperty]
         public Dictionary<string, bool> charIsLegendaryHero = new();

--- a/ToyBox/classes/Models/Settings.cs
+++ b/ToyBox/classes/Models/Settings.cs
@@ -36,7 +36,7 @@ namespace ToyBox {
 
         // This is the scaling modifier which is applied to the visual model of each character
         [JsonProperty]
-        public Dictionary<string, float> scaleVisualModelSettings = new();
+        public Dictionary<string, float> characterModelSizeMultiplier = new();
 
         // Dictionary of Name/IsLegendaryHero for configuration per party member
         [JsonProperty]

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Misc.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Misc.cs
@@ -622,9 +622,9 @@ namespace ToyBox.BagOfPatches {
         [HarmonyPatch(typeof(LogThreadService), nameof(LogThreadService.OnGameLoaded))]
         public static class LogThreadService_OnGameLoaded_Patch {
             private static void Postfix() {
-                foreach (var ID in Main.settings.perSave.scaleVisualModelSettings.Keys) {
+                foreach (var ID in Main.settings.perSave.characterModelSizeMultiplier.Keys) {
                     foreach (UnitEntityData cha in Game.Instance.State.Units.Where((u) => u.CharacterName.Equals(ID))) {
-                        float scale = Main.settings.perSave.scaleVisualModelSettings[ID];
+                        float scale = Main.settings.perSave.characterModelSizeMultiplier[ID];
                         cha.View.gameObject.transform.localScale = new Vector3(scale, scale, scale);
                     }
                 }

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Misc.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Misc.cs
@@ -52,6 +52,7 @@ using ModKit;
 using Kingmaker.EntitySystem.Persistence;
 using ToyBox.Multiclass;
 using Kingmaker.UI.MVVM._PCView.ActionBar;
+using Kingmaker.UI.Models.Log.CombatLog_ThreadSystem;
 
 namespace ToyBox.BagOfPatches {
     internal static class Misc {
@@ -616,6 +617,17 @@ namespace ToyBox.BagOfPatches {
                     return false;
                 }
                 return true;
+            }
+        }
+        [HarmonyPatch(typeof(LogThreadService), nameof(LogThreadService.OnGameLoaded))]
+        public static class LogThreadService_OnGameLoaded_Patch {
+            private static void Postfix() {
+                foreach (var ID in Main.settings.perSave.scaleVisualModelSettings.Keys) {
+                    foreach (UnitEntityData cha in Game.Instance.State.Units.Where((u) => u.CharacterName.Equals(ID))) {
+                        float scale = Main.settings.perSave.scaleVisualModelSettings[ID];
+                        cha.View.gameObject.transform.localScale = new Vector3(scale, scale, scale);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Currently uses the PerSave functions which allow a different scaling for each character for each save. I originally intended to use normal settings (which would've allowed scaling for each character, but would've been save-overarching; Narria instead showed me this method).

Ingame:
![grafik](https://user-images.githubusercontent.com/62178123/229940335-7d7745ef-4c03-4722-aab6-fb07014a22b8.png)
UI:
![grafik](https://user-images.githubusercontent.com/62178123/229940461-396a9d37-9e67-46d6-8386-fa768f5fa3b5.png)


