### PR TITLE
Update for 2.1.2d

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -64,11 +64,13 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***Narria***) Added temporary AI category to Party view.  Right now you can see what AI actions/considerations are active on a units breain. This is the beginning of an improved AI/Gambits feature which will be in its own top level tab
 * (***Narria***) Added Brains, AIActions and Considerations to Search 'n Pick
 * (***Narria***) Fixed crasher during character creaton on the loot screen
+* (***Narria***) Fixed issue where the arrow key Y scrolling becomes inverted when tilt the camera higher than like 45 or 60 degrees
 * (***ADDB***) (Experimental) Added a feature that allows hiding map loot pins on the map if the contained loot doesn't reach at least a selected rarity.
 * (***ADDB***) Added Kill on Engage toggle (Which kills a unit as soon as it joins a fight against Character).
 * (***ADDB***) Added Fog of War Radius multiplier.
 * (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
 * (***CascadingDragon***) Moved "Disallow Companions" back to Dialog section
+* (***CascadingDragon***) Added options to add points to Alignment
 ### Ver 1.4.23
 * (***Narria***) Party Editor is faster for browsing existing features/spells/etc - Blueprints don't load until you select Show All
 * (***Narria***) Deferred Blueprint loading for Armies as well

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -36,6 +36,8 @@ Enchantment: allows you to add or remove enchantments from the items in your inv
 * **Etudes**: this is a new and exciting feature that allows you to see for the first time the structure and some basic relationships of Etudes and other Elements that control the progression of your game story. Etudes are hierarchical in structure and additionally contain a set of Elements that can both conditions to check and actions to execute when the etude is started. As you browe you will notice there is a disclosure triangle next to the name which will show the children of the Etude.  Etudes that have Elements will offer a second disclosure triangle next to the status that will show them to you.
 WARNING: this tool can both miraculously fix your broken progression or it can break it even further. Save and back up your save before using. Remember that "with great power comes great responsibility"
 * **Quest Resolution**: this allows you to view your active quests and advance them as needed to work around bugs or skip quests you don't want to do.  Be warned this may break your game progression if used carelessly.
+### Ver 1.4.25
+* (***CascadingDragon***) Update for game version 2.1.2
 ### Ver 1.4.24
 * (***Narria***) Loot coloring improvents
   * Added rarity tags when color loot items is active

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -68,6 +68,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***ADDB***) Added Kill on Engage toggle (Which kills a unit as soon as it joins a fight against Character).
 * (***ADDB***) Added Fog of War Radius multiplier.
 * (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
+* (***CascadingDragon***) 
 ### Ver 1.4.23
 * (***Narria***) Party Editor is faster for browsing existing features/spells/etc - Blueprints don't load until you select Show All
 * (***Narria***) Deferred Blueprint loading for Armies as well

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -68,7 +68,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***ADDB***) Added Kill on Engage toggle (Which kills a unit as soon as it joins a fight against Character).
 * (***ADDB***) Added Fog of War Radius multiplier.
 * (***BuckAMayzing***) Prevented resurrected companions and summoned creatures from being unable to act when buff duration multiplier was set to a very high number
-* (***CascadingDragon***) 
+* (***CascadingDragon***) Moved "Disallow Companions" back to Dialog section
 ### Ver 1.4.23
 * (***Narria***) Party Editor is faster for browsing existing features/spells/etc - Blueprints don't load until you select Show All
 * (***Narria***) Deferred Blueprint loading for Armies as well

--- a/ToyBox/classes/MainUI/BagOfTricks.cs
+++ b/ToyBox/classes/MainUI/BagOfTricks.cs
@@ -219,7 +219,7 @@ namespace ToyBox {
                     Label("Experimental ".orange() + " your friends forgive even your most vile choices.".green());
                 },   
                 () => {
-                    Toggle("Disallow Companions Leaving Party", ref settings.toggleBlockUnrecruit, 300.width());
+                    Toggle("Disallow Companions Leaving Party", ref settings.toggleBlockUnrecruit);
                     25.space();
                     Label("Warning: ".color(RGBA.red) + " Only use when Friendship is Magic doesn't work, and then turn off immediately after. Can  otherwise break your save".orange());
                 },

--- a/ToyBox/classes/MainUI/LevelUp.cs
+++ b/ToyBox/classes/MainUI/LevelUp.cs
@@ -55,7 +55,6 @@ namespace ToyBox {
                     25.space();
                     Label("This allows you to select combinations of archetypes when selecting a class for the first time that contain distinct spellbooks".green());
                 },
-                //() => Toggle("Enable  'Next' when no feat selections are available", ref settings.toggleNextWhenNoAvailableFeatSelections),
                 () => Toggle("Make All Feature Selections Optional", ref settings.toggleOptionalFeatSelection),
                 () => {
                     Toggle("Ignore Attribute Cap", ref settings.toggleIgnoreAttributeCap);

--- a/ToyBox/classes/MainUI/LevelUp.cs
+++ b/ToyBox/classes/MainUI/LevelUp.cs
@@ -55,7 +55,7 @@ namespace ToyBox {
                     25.space();
                     Label("This allows you to select combinations of archetypes when selecting a class for the first time that contain distinct spellbooks".green());
                 },
-                () => Toggle("Enable  'Next' when no feat selections are available", ref settings.toggleNextWhenNoAvailableFeatSelections),
+                //() => Toggle("Enable  'Next' when no feat selections are available", ref settings.toggleNextWhenNoAvailableFeatSelections),
                 () => Toggle("Make All Feature Selections Optional", ref settings.toggleOptionalFeatSelection),
                 () => {
                     Toggle("Ignore Attribute Cap", ref settings.toggleIgnoreAttributeCap);

--- a/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
@@ -22,6 +22,8 @@ using Kingmaker.UnitLogic.Parts;
 
 namespace ToyBox {
     public partial class PartyEditor {
+        public static Kingmaker.UnitLogic.Alignments.IAlignmentShiftProvider ToyboxAlignmentProvider { get; private set; } //Will remember to set custom description... Eventually
+
         public static void OnStatsGUI(UnitEntityData ch) {
             Div(100, 20, 755);
             var alignment = ch.Descriptor.Alignment.ValueRaw;
@@ -51,6 +53,21 @@ namespace ToyBox {
                 if (SelectionGrid(ref maskIndex, titles, 3, Width(800))) {
                     ch.Descriptor.Alignment.LockAlignment(AlignmentMasks[maskIndex], new Alignment?());
                 }
+            }
+            Div(100, 20, 755);
+            using (HorizontalScope()) {
+                Space(100);
+                Label("Alignment Value", AutoWidth());
+                Space(25);
+                var increment = IntTextField(ref settings.increment, null, Width(55));
+                Space(150);
+                ActionButton($"Add {increment}" + " Law".cyan(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Lawful, increment, ToyboxAlignmentProvider), AutoWidth());
+                Space(10);
+                ActionButton($"Add {increment}" + " Chaos".pink(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Chaotic, increment, ToyboxAlignmentProvider), AutoWidth());
+                Space(10);
+                ActionButton($"Add {increment}" + " Good".green(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Good, increment, ToyboxAlignmentProvider), AutoWidth());
+                Space(10);
+                ActionButton($"Add {increment}" + " Evil".red(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Evil, increment, ToyboxAlignmentProvider), AutoWidth());
             }
             Div(100, 20, 755);
             using (HorizontalScope()) {

--- a/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
@@ -60,7 +60,6 @@ namespace ToyBox {
                 //UI.Label($"{alignmentMask.ToString()}".color(alignmentMask.Color()).bold(), UI.Width(325));
                 Label($"Experimental - this sets a mask on your alignment shifts. {"Warning".bold().orange()}{": Using this may change your alignment.".orange()}".green());
             }
-
             using (HorizontalScope()) {
                 528.space();
                 var maskIndex = Array.IndexOf(AlignmentMasks, alignmentMask);

--- a/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/StatsEditor.cs
@@ -73,21 +73,6 @@ namespace ToyBox {
             Div(100, 20, 755);
             using (HorizontalScope()) {
                 Space(100);
-                Label("Alignment Value", AutoWidth());
-                Space(25);
-                var increment = IntTextField(ref settings.increment, null, Width(55));
-                Space(150);
-                ActionButton($"Add {increment}" + " Law".cyan(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Lawful, increment, ToyboxAlignmentProvider), AutoWidth());
-                Space(10);
-                ActionButton($"Add {increment}" + " Chaos".pink(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Chaotic, increment, ToyboxAlignmentProvider), AutoWidth());
-                Space(10);
-                ActionButton($"Add {increment}" + " Good".green(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Good, increment, ToyboxAlignmentProvider), AutoWidth());
-                Space(10);
-                ActionButton($"Add {increment}" + " Evil".red(), () => ch.Descriptor.Alignment.Shift(Kingmaker.UnitLogic.Alignments.AlignmentShiftDirection.Evil, increment, ToyboxAlignmentProvider), AutoWidth());
-            }
-            Div(100, 20, 755);
-            using (HorizontalScope()) {
-                Space(100);
                 Label("Size", Width(425));
                 var size = ch.Descriptor.State.Size;
                 Label($"{size}".orange().bold(), Width(175));

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUpPatches.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUpPatches.cs
@@ -479,39 +479,6 @@ namespace ToyBox.BagOfPatches {
             }
         }
 
-        // Let user advance if no options left for feat selection, NO LONGER NEEDED as of 2.12D
-        //[HarmonyPatch(typeof(CharGenFeatureSelectorPhaseVM))]
-        //private static class CharGenFeatureSelectorPhaseVM_HandleOptionalFeatSelection_Patch {
-        //    [HarmonyPatch(nameof(CharGenFeatureSelectorPhaseVM.CheckIsCompleted))]
-        //    [HarmonyPostfix]
-        //    private static void Postfix_CharGenFeatureSelectorPhaseVM_CheckIsCompleted(CharGenFeatureSelectorPhaseVM __instance, ref bool __result) {
-
-        //        if (settings.toggleOptionalFeatSelection) {
-        //            __result = true;
-        //        }
-        //        else if (settings.toggleNextWhenNoAvailableFeatSelections || settings.featsMultiplier != 1) {
-        //            var featureSelectorStateVM = __instance.FeatureSelectorStateVM;
-        //            var selectionState = featureSelectorStateVM.SelectionState;
-        //            var selectionVM = __instance.FeatureSelectorStateVM;
-        //            var state = Game.Instance.LevelUpController.State;
-        //            IFeatureSelection selection = selection = selectionVM.Feature as IFeatureSelection;
-        //            var availableItems = selection?.Items
-        //                .Where((IFeatureSelectionItem item) => selection.CanSelect(state.Unit, state, selectionState, item));
-        //            //Main.Log($"CharGenFeatureSelectorPhaseVM_CheckIsCompleted_Patch - availableCount: {availableItems.Count()}");
-        //            if (availableItems.Count() == 0)
-        //                __result = true;
-        //        }
-        //    }
-
-        //    [HarmonyPatch(nameof(CharGenFeatureSelectorPhaseVM.OnPostBeginDetailedView))]
-        //    [HarmonyPostfix]
-        //    private static void Postfix_CharGenFeatureSelectorPhaseVM_OnPostBeginDetailedView(CharGenFeatureSelectorPhaseVM __instance) {
-        //        if (settings.toggleOptionalFeatSelection) {
-        //            __instance.IsCompleted.Value = true;
-        //        }
-        //    }
-        //}
-
 #if false
         [HarmonyPatch(typeof(ProgressionData), nameof(ProgressionData.CalculateLevelEntries))]
         public static class ProgressionData_CalculateLevelEntries_Patch {

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUpPatches.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/LevelUpPatches.cs
@@ -479,38 +479,38 @@ namespace ToyBox.BagOfPatches {
             }
         }
 
-        // Let user advance if no options left for feat selection
-        [HarmonyPatch(typeof(CharGenFeatureSelectorPhaseVM))]
-        private static class CharGenFeatureSelectorPhaseVM_HandleOptionalFeatSelection_Patch {
-            [HarmonyPatch(nameof(CharGenFeatureSelectorPhaseVM.CheckIsCompleted))]
-            [HarmonyPostfix]
-            private static void Postfix_CharGenFeatureSelectorPhaseVM_CheckIsCompleted(CharGenFeatureSelectorPhaseVM __instance, ref bool __result) {
+        // Let user advance if no options left for feat selection, NO LONGER NEEDED as of 2.12D
+        //[HarmonyPatch(typeof(CharGenFeatureSelectorPhaseVM))]
+        //private static class CharGenFeatureSelectorPhaseVM_HandleOptionalFeatSelection_Patch {
+        //    [HarmonyPatch(nameof(CharGenFeatureSelectorPhaseVM.CheckIsCompleted))]
+        //    [HarmonyPostfix]
+        //    private static void Postfix_CharGenFeatureSelectorPhaseVM_CheckIsCompleted(CharGenFeatureSelectorPhaseVM __instance, ref bool __result) {
 
-                if (settings.toggleOptionalFeatSelection) {
-                    __result = true;
-                }
-                else if (settings.toggleNextWhenNoAvailableFeatSelections || settings.featsMultiplier != 1) {
-                    var featureSelectorStateVM = __instance.FeatureSelectorStateVM;
-                    var selectionState = featureSelectorStateVM.SelectionState;
-                    var selectionVM = __instance.FeatureSelectorStateVM;
-                    var state = Game.Instance.LevelUpController.State;
-                    IFeatureSelection selection = selection = selectionVM.Feature as IFeatureSelection;
-                    var availableItems = selection?.Items
-                        .Where((IFeatureSelectionItem item) => selection.CanSelect(state.Unit, state, selectionState, item));
-                    //Main.Log($"CharGenFeatureSelectorPhaseVM_CheckIsCompleted_Patch - availableCount: {availableItems.Count()}");
-                    if (availableItems.Count() == 0)
-                        __result = true;
-                }
-            }
+        //        if (settings.toggleOptionalFeatSelection) {
+        //            __result = true;
+        //        }
+        //        else if (settings.toggleNextWhenNoAvailableFeatSelections || settings.featsMultiplier != 1) {
+        //            var featureSelectorStateVM = __instance.FeatureSelectorStateVM;
+        //            var selectionState = featureSelectorStateVM.SelectionState;
+        //            var selectionVM = __instance.FeatureSelectorStateVM;
+        //            var state = Game.Instance.LevelUpController.State;
+        //            IFeatureSelection selection = selection = selectionVM.Feature as IFeatureSelection;
+        //            var availableItems = selection?.Items
+        //                .Where((IFeatureSelectionItem item) => selection.CanSelect(state.Unit, state, selectionState, item));
+        //            //Main.Log($"CharGenFeatureSelectorPhaseVM_CheckIsCompleted_Patch - availableCount: {availableItems.Count()}");
+        //            if (availableItems.Count() == 0)
+        //                __result = true;
+        //        }
+        //    }
 
-            [HarmonyPatch(nameof(CharGenFeatureSelectorPhaseVM.OnPostBeginDetailedView))]
-            [HarmonyPostfix]
-            private static void Postfix_CharGenFeatureSelectorPhaseVM_OnPostBeginDetailedView(CharGenFeatureSelectorPhaseVM __instance) {
-                if (settings.toggleOptionalFeatSelection) {
-                    __instance.IsCompleted.Value = true;
-                }
-            }
-        }
+        //    [HarmonyPatch(nameof(CharGenFeatureSelectorPhaseVM.OnPostBeginDetailedView))]
+        //    [HarmonyPostfix]
+        //    private static void Postfix_CharGenFeatureSelectorPhaseVM_OnPostBeginDetailedView(CharGenFeatureSelectorPhaseVM __instance) {
+        //        if (settings.toggleOptionalFeatSelection) {
+        //            __instance.IsCompleted.Value = true;
+        //        }
+        //    }
+        //}
 
 #if false
         [HarmonyPatch(typeof(ProgressionData), nameof(ProgressionData.CalculateLevelEntries))]


### PR DESCRIPTION
"During level up, if all feats from the list had been previously taken, it was impossible to finish the level up – fixed;"
From Owlcat's patch notes. 
Toybox's patch that did the same thing caused Toybox to error on load. Simply commented it out.
Not sure why the PR shows changes Narria already merged in (and then changed so it looks better) but that's on me to learn how Git works 