### PR TITLE
Browser Change

### DIFF
--- a/ModKit/UI/UI+Browser.cs
+++ b/ModKit/UI/UI+Browser.cs
@@ -23,7 +23,7 @@ namespace ModKit {
             private string _searchText = "";
             private int _searchLimit = 100;
             private int _pageCount;
-            private int _currentPage;
+            private int _currentPage = 1;
             public bool _searchChanged = true;
             private int _matchCount;
             private bool _showAll;
@@ -89,12 +89,21 @@ namespace ModKit {
                             Label(matchesText, ExpandWidth(false));
                         }
                         if (_matchCount > _searchLimit) {
-                            string pageText = "Page: ".orange() + _currentPage.ToString().cyan() + " / " + _pageCount.ToString().cyan();
-                            pageText += "   ";
+                            string pageLabel = "Page: ".orange() + _currentPage.ToString().cyan() + " / " + _pageCount.ToString().cyan();
                             25.space();
-                            if (ValueAdjustorEditable(pageText, () => _currentPage, (v) => _currentPage = v, 1, 1, _pageCount, AutoWidth())) {
-                                _updatePages = true;
-                            }
+                            Label(pageLabel, ExpandWidth(false));
+                            ActionButton("-", () => {
+                                if (_currentPage > 1) {
+                                    _currentPage -= 1;
+                                    _updatePages = true;
+                                }
+                            }, AutoWidth());
+                            ActionButton("+", () => {
+                                if (_currentPage < _pageCount) {
+                                    _currentPage += 1;
+                                    _updatePages = true;
+                                }
+                            }, AutoWidth());
                         }
                     }
                 }
@@ -206,6 +215,7 @@ namespace ModKit {
                 if (_searchLimit > 0) {
                     _pageCount = (int)Math.Ceiling((double)_matchCount / _searchLimit);
                     _currentPage = Math.Min(_currentPage, _pageCount);
+                    _currentPage = Math.Max(1, _currentPage);
                 } else {
                     _pageCount = 1;
                     _currentPage = 1;

--- a/ModKit/UI/UI+Browser.cs
+++ b/ModKit/UI/UI+Browser.cs
@@ -24,7 +24,7 @@ namespace ModKit {
             private int _searchLimit = 100;
             private int _pageCount;
             private int _currentPage;
-            private bool _searchChanged = true;
+            public bool _searchChanged = true;
             private int _matchCount;
             private bool _showAll;
             private bool _updatePages = false;
@@ -54,11 +54,12 @@ namespace ModKit {
                 bool search = true,
                 float titleMinWidth = 100,
                 float titleMaxWidth = 300,
-                int ticksPerUpdate = 1
+                int ticksPerUpdate = 1,
+                bool noTickNecessary = false
                 ) {
                 if (searchKey == null) searchKey = title;
                 if (sortKey == null) sortKey = title;
-                List<Definition> definitions = update(current, available, title, search, searchKey, sortKey, definition, ticksPerUpdate);
+                List<Definition> definitions = update(current, available, title, search, searchKey, sortKey, definition, ticksPerUpdate, noTickNecessary);
                 _tick++;
                 if (search || _searchLimit < _matchCount) {
                     if (search) {
@@ -141,12 +142,13 @@ namespace ModKit {
                 }
             }
 
-            private List<Definition> update(IEnumerable<Item> current, Func<IEnumerable<Definition>> available, Func<Definition, string> title,
-                bool search, Func<Definition, string> searchKey, Func<Definition, string> sortKey, Func<Item, Definition> definition, int ticksPerUpdate) {
+            private List<Definition> update(IEnumerable<Item> current, Func<IEnumerable<Definition>> available, Func<Definition, string> title, bool search,
+                Func<Definition, string> searchKey, Func<Definition, string> sortKey, Func<Item, Definition> definition, int ticksPerUpdate, bool noTickNecessary) {
                 if (_showAll && _availableIsStatic && (_availableCache == null || _availableCache?.Count() == 0)) {
                     _availableCache = available();
+                    _searchChanged = true;
                 }
-                if (_searchChanged || _tick % ticksPerUpdate == 0) {
+                if (_searchChanged || (_tick % ticksPerUpdate == 0 && !noTickNecessary)) {
                     _currentDict = current.ToDictionaryIgnoringDuplicates(definition, c => c);
                     var defs = (_showAll) ? ((_availableIsStatic) ? _availableCache : available()) : _currentDict.Keys.ToList();
                     UpdateSearchResults(_searchText, defs, searchKey, sortKey, title, search);

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -44,6 +44,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***Narria***) Added Dice Roll overrides for Skill checks only (thanks AlterAsc) and cleaned up the options a bit to make them more clear
 * (***Marria***) Search 'n Pick: Added counts to the collation categories
 * (***Narria***) Search 'n Pick: Fixed various duplicate value issues when using sub-categories
+* (***ADDB***) Changed Browser to improve performance.
 * (***ADDB***) Fixed belt consumable feature.
 * (***ADDB***) Reroll Perception button now also rerolls perception on the global map.
 * (***ADDB***) Fixed belt consumable feature.

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -46,6 +46,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***Narria***) Search 'n Pick: Fixed various duplicate value issues when using sub-categories
 * (***ADDB***) Changed Browser to improve performance.
 * (***ADDB***) Fixed belt consumable feature.
+* (***ADDB***) Fixed visual size scaling breaking when using any sort of polymorph.
 * (***ADDB***) Reroll Perception button now also rerolls perception on the global map.
 * (***ADDB***) Fixed belt consumable feature.
 * (***ADDB***) Fix Murder Hobo for Leaper's Smile swarms.

--- a/ToyBox/classes/MainUI/Crusade/ArmiesEditor.cs
+++ b/ToyBox/classes/MainUI/Crusade/ArmiesEditor.cs
@@ -239,7 +239,7 @@ namespace ToyBox.classes.MainUI {
                                                     Label("Weird", AutoWidth());
                                                 }
                                             }
-                                        }, null, 50, true, true, 100, 300, 1, true);
+                                        }, null, 50, true, true, 100, 300, 600, false);
                             }
                         }
                     });

--- a/ToyBox/classes/MainUI/Crusade/ArmiesEditor.cs
+++ b/ToyBox/classes/MainUI/Crusade/ArmiesEditor.cs
@@ -7,19 +7,14 @@ using Kingmaker.Blueprints.Root;
 using Kingmaker.Globalmap.State;
 using Kingmaker.Globalmap.View;
 using Kingmaker.Kingdom;
-using Kingmaker.Kingdom.Blueprints;
+using Kingmaker.PubSubSystem;
 using Kingmaker.UnitLogic.Abilities.Blueprints;
-using Kingmaker.Kingdom.Armies;
 using ModKit;
-using static ModKit.UI;
 using ModKit.Utility;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine;
 using UnityModManagerNet;
-using Kingmaker.PubSubSystem;
-using static Kingmaker.Dungeon.DungeonStageState;
-using Kingmaker.Cheats;
+using static ModKit.UI;
 
 namespace ToyBox.classes.MainUI {
     public static class ArmiesEditor {
@@ -29,6 +24,7 @@ namespace ToyBox.classes.MainUI {
         public static IEnumerable<(GlobalMapArmyState, float)> playerArmies;
         public static IEnumerable<(GlobalMapArmyState, float)> demonArmies;
         public static string skillsSearchText = "";
+        public static Browser<BlueprintUnit, BlueprintUnit> browser = new();
 
 
         public static void OnShowGUI() => UpdateArmies();
@@ -166,80 +162,82 @@ namespace ToyBox.classes.MainUI {
                     () => DisclosureToggle("Recruitment Pools".Orange(), ref discloseMercenaryUnits),
                     () => {
                         if (discloseMercenaryUnits) {
-                            if (armyBlueprints == null || armyBlueprints?.Count() == 0) {
-                                LoadMercenaryData();
-                            }
                             using (VerticalScope()) {
                                 bool changed = false;
-                                Browser<BlueprintUnit, BlueprintUnit>.OnGUI(
-                                    "Army Units",
-                                    ref changed,
-                                    mercenaryUnits,
-                                    () => armyBlueprints,
-                                    (unit) => unit,
-                                    (unit) => unit.NameSafe(),
-                                    (unit) => IsInRecruitPool.GetValueOrDefault(unit.GetHashCode(), false) ? unit.GetDisplayName().orange().bold() : unit.GetDisplayName(),
-                                    (unit) => $"{unit.NameSafe()} {unit.GetDisplayName()} {unit.Description}",
-                                    (unit) => unit.GetDisplayName(),
-                                    () => {
-                                        var bluh = ummWidth - 50;
-                                        var titleWidth = (bluh / (IsWide ? 3.0f : 4.0f)) - 100;
-                                        Label("Unit", Width((int)titleWidth));
-                                        35.space();
-                                        Label("Action", Width(310));
-                                        28.space();
-                                        Label("Pool", Width(200));
-                                        25.space();
-                                        Label("Recruitment Weight (Mercenary only)", AutoWidth());
-                                    },
-                                    (bpUnit, unit) => {
-                                        bool isInMercPool = IsInMercenaryPool.GetValueOrDefault(unit.GetHashCode(), false);
-                                        bool isInKingdomPool = IsInRecruitPool.GetValueOrDefault(unit.GetHashCode(), recruitPool.Contains(unit));
-                                        ActionButton(isInMercPool ? "Rem Merc" : "Add Merc",
-                                                    () => {
-                                                        if (isInMercPool) {
-                                                            mercenaryManager.RemoveMercenary(unit);
-                                                            isInMercPool = false;
-                                                        }
-                                                        else {
-                                                            mercenaryManager.AddMercenary(unit, 1);
-                                                            isInMercPool = true;
-                                                        }
-                                                        IsInMercenaryPool[unit.GetHashCode()] = isInMercPool;
-                                                    }, 150.width());
-                                        10.space();
-                                        ActionButton(isInKingdomPool ? "Rem Recruit" : "Add Recruit",
-                                                    () => {
-                                                        if (isInKingdomPool) {
-                                                            var count = recruitsManager.GetCountInPool(unit);
-                                                            recruitsManager.DecreasePool(unit, count);
-                                                            isInKingdomPool = false;
-                                                        }
-                                                        else {
-                                                            var pool = recruitsManager.Pool;
-                                                            var count = pool.Sum(r =>  r.Count) / pool.Count;
-                                                            recruitsManager.IncreasePool(unit, count);
-                                                            isInKingdomPool = true;
-                                                        }
-                                                        IsInRecruitPool[unit.GetHashCode()] = isInKingdomPool;
-                                                    }, 150.width());
-                                        var poolText = $"{(isInMercPool ? $"Merc".cyan() : "")} {(isInKingdomPool ? $"Recruit ({recruitsManager.GetCountInPool(unit)})".orange() : "")}".Trim();
-                                        50.space();
-                                        Label(poolText, Width(200));
-                                        25.space();
-                                        if (isInMercPool) {
-                                            var poolInfo = mercenaryManager.Pool.FirstOrDefault(pi => pi.Unit == unit);
-                                            if (poolInfo != null) {
-                                                var weight = poolInfo.Weight;
-                                                if (LogSliderCustomLabelWidth("Weight", ref weight, 0.01f, 1000, 1, 2, "", 70, AutoWidth())) {
-                                                    poolInfo.UpdateWeight(weight);
+                                browser.OnGUI(
+                                        "Army Units",
+                                        ref changed,
+                                        mercenaryUnits,
+                                        () => {
+                                            if (armyBlueprints == null || armyBlueprints?.Count() == 0) {
+                                                LoadMercenaryData();
+                                            }
+                                            return armyBlueprints;
+                                        },
+                                        (unit) => unit,
+                                        (unit) => unit.NameSafe(),
+                                        (unit) => IsInRecruitPool.GetValueOrDefault(unit.GetHashCode(), false) ? unit.GetDisplayName().orange().bold() : unit.GetDisplayName(),
+                                        (unit) => $"{unit.NameSafe()} {unit.GetDisplayName()} {unit.Description}",
+                                        (unit) => unit.GetDisplayName(),
+                                        () => {
+                                            var bluh = ummWidth - 50;
+                                            var titleWidth = (bluh / (IsWide ? 3.0f : 4.0f)) - 100;
+                                            Label("Unit", Width((int)titleWidth));
+                                            35.space();
+                                            Label("Action", Width(310));
+                                            28.space();
+                                            Label("Pool", Width(200));
+                                            25.space();
+                                            Label("Recruitment Weight (Mercenary only)", AutoWidth());
+                                        },
+                                        (bpUnit, unit) => {
+                                            bool isInMercPool = IsInMercenaryPool.GetValueOrDefault(unit.GetHashCode(), false);
+                                            bool isInKingdomPool = IsInRecruitPool.GetValueOrDefault(unit.GetHashCode(), recruitPool.Contains(unit));
+                                            ActionButton(isInMercPool ? "Rem Merc" : "Add Merc",
+                                                        () => {
+                                                            if (isInMercPool) {
+                                                                mercenaryManager.RemoveMercenary(unit);
+                                                                isInMercPool = false;
+                                                            }
+                                                            else {
+                                                                mercenaryManager.AddMercenary(unit, 1);
+                                                                isInMercPool = true;
+                                                            }
+                                                            IsInMercenaryPool[unit.GetHashCode()] = isInMercPool;
+                                                        }, 150.width());
+                                            10.space();
+                                            ActionButton(isInKingdomPool ? "Rem Recruit" : "Add Recruit",
+                                                        () => {
+                                                            if (isInKingdomPool) {
+                                                                var count = recruitsManager.GetCountInPool(unit);
+                                                                recruitsManager.DecreasePool(unit, count);
+                                                                isInKingdomPool = false;
+                                                            }
+                                                            else {
+                                                                var pool = recruitsManager.Pool;
+                                                                var count = pool.Sum(r => r.Count) / pool.Count;
+                                                                recruitsManager.IncreasePool(unit, count);
+                                                                isInKingdomPool = true;
+                                                            }
+                                                            IsInRecruitPool[unit.GetHashCode()] = isInKingdomPool;
+                                                        }, 150.width());
+                                            var poolText = $"{(isInMercPool ? $"Merc".cyan() : "")} {(isInKingdomPool ? $"Recruit ({recruitsManager.GetCountInPool(unit)})".orange() : "")}".Trim();
+                                            50.space();
+                                            Label(poolText, Width(200));
+                                            25.space();
+                                            if (isInMercPool) {
+                                                var poolInfo = mercenaryManager.Pool.FirstOrDefault(pi => pi.Unit == unit);
+                                                if (poolInfo != null) {
+                                                    var weight = poolInfo.Weight;
+                                                    if (LogSliderCustomLabelWidth("Weight", ref weight, 0.01f, 1000, 1, 2, "", 70, AutoWidth())) {
+                                                        poolInfo.UpdateWeight(weight);
+                                                    }
+                                                }
+                                                else {
+                                                    Label("Weird", AutoWidth());
                                                 }
                                             }
-                                            else {
-                                                Label("Weird", AutoWidth());
-                                            }
-                                        }
-                                    });
+                                        });
                             }
                         }
                     });

--- a/ToyBox/classes/MainUI/Crusade/ArmiesEditor.cs
+++ b/ToyBox/classes/MainUI/Crusade/ArmiesEditor.cs
@@ -24,7 +24,7 @@ namespace ToyBox.classes.MainUI {
         public static IEnumerable<(GlobalMapArmyState, float)> playerArmies;
         public static IEnumerable<(GlobalMapArmyState, float)> demonArmies;
         public static string skillsSearchText = "";
-        public static Browser<BlueprintUnit, BlueprintUnit> browser = new();
+        public static Browser<BlueprintUnit, BlueprintUnit> browser = new(true);
 
 
         public static void OnShowGUI() => UpdateArmies();
@@ -195,6 +195,7 @@ namespace ToyBox.classes.MainUI {
                                             bool isInKingdomPool = IsInRecruitPool.GetValueOrDefault(unit.GetHashCode(), recruitPool.Contains(unit));
                                             ActionButton(isInMercPool ? "Rem Merc" : "Add Merc",
                                                         () => {
+                                                            browser._searchChanged = true;
                                                             if (isInMercPool) {
                                                                 mercenaryManager.RemoveMercenary(unit);
                                                                 isInMercPool = false;
@@ -208,6 +209,7 @@ namespace ToyBox.classes.MainUI {
                                             10.space();
                                             ActionButton(isInKingdomPool ? "Rem Recruit" : "Add Recruit",
                                                         () => {
+                                                            browser._searchChanged = true;
                                                             if (isInKingdomPool) {
                                                                 var count = recruitsManager.GetCountInPool(unit);
                                                                 recruitsManager.DecreasePool(unit, count);
@@ -237,7 +239,7 @@ namespace ToyBox.classes.MainUI {
                                                     Label("Weird", AutoWidth());
                                                 }
                                             }
-                                        });
+                                        }, null, 50, true, true, 100, 300, 1, true);
                             }
                         }
                     });

--- a/ToyBox/classes/MainUI/Crusade/ArmiesEditor.cs
+++ b/ToyBox/classes/MainUI/Crusade/ArmiesEditor.cs
@@ -24,8 +24,7 @@ namespace ToyBox.classes.MainUI {
         public static IEnumerable<(GlobalMapArmyState, float)> playerArmies;
         public static IEnumerable<(GlobalMapArmyState, float)> demonArmies;
         public static string skillsSearchText = "";
-        public static Browser<BlueprintUnit, BlueprintUnit> browser = new(true);
-
+        public static Browser<BlueprintUnit, BlueprintUnit> browser = new(true, 600, true, true);
 
         public static void OnShowGUI() => UpdateArmies();
         public static void UpdateArmies() {
@@ -195,7 +194,7 @@ namespace ToyBox.classes.MainUI {
                                             bool isInKingdomPool = IsInRecruitPool.GetValueOrDefault(unit.GetHashCode(), recruitPool.Contains(unit));
                                             ActionButton(isInMercPool ? "Rem Merc" : "Add Merc",
                                                         () => {
-                                                            browser._searchChanged = true;
+                                                            browser.searchChanged = true;
                                                             if (isInMercPool) {
                                                                 mercenaryManager.RemoveMercenary(unit);
                                                                 isInMercPool = false;
@@ -209,7 +208,7 @@ namespace ToyBox.classes.MainUI {
                                             10.space();
                                             ActionButton(isInKingdomPool ? "Rem Recruit" : "Add Recruit",
                                                         () => {
-                                                            browser._searchChanged = true;
+                                                            browser.searchChanged = true;
                                                             if (isInKingdomPool) {
                                                                 var count = recruitsManager.GetCountInPool(unit);
                                                                 recruitsManager.DecreasePool(unit, count);
@@ -239,7 +238,7 @@ namespace ToyBox.classes.MainUI {
                                                     Label("Weird", AutoWidth());
                                                 }
                                             }
-                                        }, null, 50, true, true, 100, 300, 600, false);
+                                        });
                             }
                         }
                     });

--- a/ToyBox/classes/MainUI/PartyEditor/BrainEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/BrainEditor.cs
@@ -9,9 +9,9 @@ using static ModKit.UI;
 
 namespace ToyBox {
     public partial class PartyEditor {
-        public static Browser<AiAction, BlueprintAiAction> browser = new();
-        public static Browser<Consideration, Consideration> browser2 = new();
-        public static Browser<Consideration, Consideration> browser3 = new();
+        public static Browser<AiAction, BlueprintAiAction> browser = new(true, 600, true, true);
+        public static Browser<Consideration, Consideration> browser2 = new(true, 600, true, true);
+        public static Browser<Consideration, Consideration> browser3 = new(true, 15, true, true);
         public static void OnBrainGUI(UnitEntityData ch) {
             bool changed = false;
             browser.OnGUI(
@@ -32,7 +32,7 @@ namespace ToyBox {
                 },
                 (action, bp) => {
                     bool changed = false;
-                    if (action.ActorConsiderations.Count > 0) {
+                    if (action?.ActorConsiderations.Count > 0) {
                         using (HorizontalScope()) {
                             150.space();
                             Label($"{"Actor Considerations".orange().bold()} - {ch.CharacterName.cyan()}");
@@ -63,7 +63,7 @@ namespace ToyBox {
                     browser3.OnGUI(
                         $"{ch.CharacterName}-{bp.AssetGuid}-TargetConsiderations",
                         ref changed,
-                        action.TargetConsiderations,
+                        action?.TargetConsiderations,
                         () => BlueprintExtensions.GetBlueprints<Consideration>(),
                         c => c,
                         c => c.AssetGuid.ToString(),

--- a/ToyBox/classes/MainUI/PartyEditor/BrainEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/BrainEditor.cs
@@ -1,40 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Kingmaker;
-using Kingmaker.Blueprints.Classes;
-using Kingmaker.Blueprints.Classes.Spells;
-using Kingmaker.Designers;
-using Kingmaker.EntitySystem.Entities;
-using Kingmaker.EntitySystem.Stats;
-using Kingmaker.UnitLogic;
-using ToyBox.Multiclass;
-using Alignment = Kingmaker.Enums.Alignment;
-using ModKit;
-using static ModKit.UI;
-using ModKit.Utility;
-using ToyBox.classes.Infrastructure;
-using Kingmaker.PubSubSystem;
-using Kingmaker.Blueprints;
-using Kingmaker.UnitLogic.FactLogic;
-using Kingmaker.UnitLogic.Parts;
-using static Kingmaker.Utility.UnitDescription.UnitDescription;
-using Kingmaker.AI;
+﻿using Kingmaker.AI;
 using Kingmaker.AI.Blueprints;
 using Kingmaker.AI.Blueprints.Considerations;
-using System.Web.UI;
+using Kingmaker.EntitySystem.Entities;
+using ModKit;
+using System;
+using System.Linq;
+using static ModKit.UI;
 
 namespace ToyBox {
     public partial class PartyEditor {
+        public static Browser<AiAction, BlueprintAiAction> browser = new();
+        public static Browser<Consideration, Consideration> browser2 = new();
+        public static Browser<Consideration, Consideration> browser3 = new();
         public static void OnBrainGUI(UnitEntityData ch) {
             bool changed = false;
-            Browser<AiAction, BlueprintAiAction>.OnGUI(
+            browser.OnGUI(
                 $"{ch.CharacterName}-Gambits",
                 ref changed,
                 ch.Brain.Actions,
@@ -57,7 +37,7 @@ namespace ToyBox {
                             150.space();
                             Label($"{"Actor Considerations".orange().bold()} - {ch.CharacterName.cyan()}");
                         }
-                        Browser<Consideration, Consideration>.OnGUI(
+                        browser2.OnGUI(
                             $"{ch.CharacterName}-{bp.AssetGuid}-ActorConsiderations",
                             ref changed,
                             action.ActorConsiderations,
@@ -80,7 +60,7 @@ namespace ToyBox {
                         150.space();
                         Label($"Target Consideration".orange());
                     }
-                    Browser<Consideration, Consideration>.OnGUI(
+                    browser3.OnGUI(
                         $"{ch.CharacterName}-{bp.AssetGuid}-TargetConsiderations",
                         ref changed,
                         action.TargetConsiderations,


### PR DESCRIPTION
This PR introduces two changes. The first is that I added Pages to the ModKit Browser:
![grafik](https://user-images.githubusercontent.com/62178123/231564643-26bd34e5-4078-4f4d-a662-cc032aabc2a6.png)

The second is that I reworked the Browser implementation. For that I turned the static browser into an instanced one and added three possible optimization steps which should improve UI performance.

1. It is possible to pass an optional bool availableIsStatic to the constructor. This should be based on the use case. Does the return value of the available() function change? If not, then to prevent unnecessary load from repeatedly calling the function it will cache the result and use that instead. If it does change (default behaviour availableIsStatic=false) then just call available as always. This would probably help with performance when available is a resource intense function that doesn't change its return value... so not much in hindsight;

2. Added int ticksPerUpdate as a parameter to onGUI
- I moved the actual search logic out of onGUI. Only a search function is called at the beginning of onGUI
- The search will either return the previous result or actually perform the search. A search will only be performed if the (now public) _searchChanged bool is set to true or (_tick % ticksPerUpdate == 0). _tick is a variable that is raised once per OnGUI call
- That means that (assuming 60 onGUI calls/s) a ticksPerUpdate parameter of 15 would perform 4 searched per second regardless of the _searchChanged variable. (instead of always 60 as it was previously)
- The default behaviour is `ticksPerUpdate=1 `to copy previous behaviour; though this could be changed to improve default performance.

3. Added bool noTickNecessary as a parameter to onGUI
- The default behaviour is `noTickNecessary=false `to copy previous behaviour; this should not be changed
- What this does is assume that either both Available AND Current are either unchaning pieces of data, or every change will be marked using the _searchChanged bool
- This means that a search is only performed when truly necessary, but needs additional thought from the programmer on how to use the browser
- I added this to the Mercenary Browser as an example. If I just left it as previously but set noTickNecessary as true, performance will improve, but at the same time changes made to Current will not register. That means if you remove Recruits/Mercenaries from the available pool it won't update by actually removing the units (assuming Show All is deactivated since they would be shown anyway with that on). To change that, I added `browser._searchChanged = true `to both buttons;
- With doing that, the only problem to the noTickNecessary approach is when "unexpected" changes happen (i.e. when a user unlocks Mercenary/Recruit unit manually; that change won't be registered until a search is done manually or Show All is disclosed).

Summary of optimazion:
1. If the data returned from available() is always the same (after first load), passing true in the constructor might show a slight improvement without downsides.
2. ticksPerUpdate reduces the amount of (not event based) searched. This reduces reactivity to unconsidered changes in the available or current list for (at least in my opinion) significant performance gains for a high ticksPerUpdate rate.
3. noTickNecessary basically overrides ticksPerUpdate and disables non-event based updates completely. While the performance gains are (again, in my opinion) great, if there is any chance of non-considered updates (like the abovementioned game unlocking new recruitable units or mercenary units), a very high ticksPerUpdate rate (300 = 5s; 600 = 10s or even 3600 = 1min) should be preferred since the performance is nearly identical, but the update will be (even if a little delayed) noticed without the user having to press search or trigger any other searchChanged event)


I only applied the optimizations to Mercenary Browser since I didn't really take a closer look to the others; but that's bascially the current status.