### PR TITLE
Asynch browser search

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -128,3 +128,4 @@ resharper_place_linq_into_on_new_line = false
 resharper_place_simple_case_statement_on_same_line = true
 resharper_wrap_chained_binary_expressions = chop_if_long
 resharper_wrap_chained_binary_patterns = chop_if_long
+csharp_new_line_before_else = true

--- a/ModKit/UI/UI+Browser.cs
+++ b/ModKit/UI/UI+Browser.cs
@@ -93,7 +93,7 @@ namespace ModKit {
                                 if (!SearchAsYouType) return;
                                 needsReloadData = true;
                                 _searchQueryChanged = true;
-                            }, () => { needsReloadData = true; }, width(320));
+                            }, () => { needsReloadData = true; }, MinWidth(320), AutoWidth());
                             25.space();
                             Label("Limit", ExpandWidth(false));
                             var searchLimit = SearchLimit;

--- a/ModKit/UI/UI+Browser.cs
+++ b/ModKit/UI/UI+Browser.cs
@@ -3,6 +3,8 @@ using ModKit.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using ToyBox;
 using UnityEngine;
 
@@ -16,9 +18,11 @@ namespace ModKit {
             // You an also provide UI that renders children below the row
             public Settings Settings => Main.settings; // FIXME - move these settings into ModKit. Can't have dependency on ToyBox
             private IEnumerable<Definition> _pagedResults = new List<Definition>();
-            public IEnumerable<Definition> filteredOrderedDefinitions;
+            private Queue<Definition> cachedSearchResults;
+            public SortedSet<Definition> filteredDefinitions;
             private Dictionary<Definition, Item> _currentDict;
             private readonly Dictionary<string, bool> _disclosureStates = new();
+            private CancellationTokenSource _cancellationTokenSource;
             private string _searchText = "";
             public bool SearchAsYouType;
             public bool ShowAll;
@@ -35,11 +39,13 @@ namespace ModKit {
             private int _pageCount;
             private int _matchCount;
             private int _currentPage = 1;
-            private DateTime _lockedUntil;
+            private bool _searchQueryChanged = true;
             public bool needsReloadData = true;
             public void ReloadData() => needsReloadData = true;
             private bool _updatePages = false;
-            private bool _startedLoading = false;
+            private bool _finishedSearch = false;
+            public bool isSearching = false;
+            private bool _startedLoadingAvailable = false;
             private readonly bool _availableIsStatic;
             private List<Definition> _availableCache;
             private string _prevCallerKey = string.Empty;
@@ -85,8 +91,8 @@ namespace ModKit {
                             indent.space();
                             ActionTextField(ref _searchText, "searchText", (text) => {
                                 if (!SearchAsYouType) return;
-                                _lockedUntil = DateTime.Now.AddMilliseconds(250);
                                 needsReloadData = true;
+                                _searchQueryChanged = true;
                             }, () => { needsReloadData = true; }, width(320));
                             25.space();
                             Label("Limit", ExpandWidth(false));
@@ -95,8 +101,15 @@ namespace ModKit {
                             if (searchLimit > 1000) { searchLimit = 1000; }
                             SearchLimit = searchLimit;
                             25.space();
-                            _startedLoading |= DisclosureToggle("Show All".Orange().Bold(), ref ShowAll, () => ReloadData());
+                            if (DisclosureToggle("Show All".Orange().Bold(), ref ShowAll)) {
+                                _startedLoadingAvailable |= ShowAll;
+                                ReloadData();
+                            }
                             25.space();
+                            if (isSearching) {
+                                Label("Searching...", AutoWidth());
+                                25.space();
+                            }
                         }
                     } else {
                         if (_searchText != searchTextPassedFromParent) {
@@ -197,22 +210,50 @@ namespace ModKit {
             private List<Definition> Update(IEnumerable<Item> current, Func<IEnumerable<Definition>> available, Func<Definition, string> title, bool search,
                 Func<Definition, string> searchKey, Func<Definition, string> sortKey, Func<Item, Definition> definition) {
                 if (Event.current.type == EventType.Layout) {
-                    if (_startedLoading) {
+                    if (_startedLoadingAvailable) {
                         _availableCache = available()?.ToList();
                         if (_availableCache?.Count() > 0) {
-                            _startedLoading = false;
+                            _startedLoadingAvailable = false;
                             needsReloadData = true;
                             if (!_availableIsStatic) {
                                 _availableCache = null;
                             }
                         }
                     }
+                    if (_finishedSearch || isSearching) {
+                        // If the search has at least one result
+                        if (cachedSearchResults.Count > 0 && (_searchQueryChanged || _finishedSearch)) {
+                            if (_finishedSearch && !_searchQueryChanged) {
+                                filteredDefinitions = new SortedSet<Definition>(Comparer<Definition>.Create((x, y) => sortKey(x).CompareTo(sortKey(y))));
+                            }
+                            Queue<Definition> tmp;
+                            // Lock the search results
+                            lock (cachedSearchResults) {
+                                // Quickly create copy of current results
+                                tmp = new Queue<Definition>(cachedSearchResults);
+                            }
+                            // Go through every item in the queue
+                            while (tmp.Count > 0) {
+                                // Add the item into the OrderedSet filteredDefinitions
+                                filteredDefinitions.Add(tmp.Dequeue());
+                            }
+                        }
+                        _matchCount = filteredDefinitions.Count;
+                        UpdatePageCount();
+                        UpdatePaginatedResults();
+                        if (_finishedSearch) {
+                            isSearching = false;
+                            _updatePages = false;
+                            _finishedSearch = false;
+                            _searchQueryChanged = false;
+                            cachedSearchResults = null;
+                        }
+                    }
                     if (needsReloadData) {
-                        if (DateTime.Now.CompareTo(_lockedUntil) < 0) return _pagedResults?.ToList();
                         _currentDict = current.ToDictionaryIgnoringDuplicates(definition, c => c);
                         IEnumerable<Definition> definitions;
                         if (ShowAll) {
-                            if (_startedLoading) {
+                            if (_startedLoadingAvailable) {
                                 definitions = _currentDict.Keys.ToList();
                             } else if (_availableIsStatic) {
                                 definitions = _availableCache;
@@ -222,9 +263,19 @@ namespace ModKit {
                         } else {
                             definitions = _currentDict.Keys.ToList();
                         }
-                        UpdateSearchResults(_searchText, definitions, searchKey, sortKey, title, search);
-                        needsReloadData = false;
-                    } else if (_updatePages) {
+                        if (!isSearching) {
+                            _cancellationTokenSource = new();
+                            Task.Run(() => UpdateSearchResults(_searchText, definitions, searchKey, sortKey, title, search));
+                            if (_searchQueryChanged) {
+                                filteredDefinitions = new SortedSet<Definition>(Comparer<Definition>.Create((x, y) => sortKey(x).CompareTo(sortKey(y))));
+                            }
+                            isSearching = true;
+                            needsReloadData = false;
+                        } else {
+                            _cancellationTokenSource.Cancel();
+                        }
+                    }
+                    if (_updatePages) {
                         _updatePages = false;
                         UpdatePageCount();
                         UpdatePaginatedResults();
@@ -244,11 +295,14 @@ namespace ModKit {
                 if (definitions == null) {
                     return;
                 }
-                var filtered = new List<Definition>();
+                cachedSearchResults = new();
                 var terms = searchTextParam.Split(' ').Select(s => s.ToLower()).ToHashSet();
-
                 if (search) {
                     foreach (var def in definitions) {
+                        if (_cancellationTokenSource.IsCancellationRequested) {
+                            isSearching = false;
+                            return;
+                        }
                         var name = title(def);
                         var nameLower = name.ToLower();
                         // Should items without name still be supported?
@@ -257,22 +311,24 @@ namespace ModKit {
                         }
                         if (def.GetType().ToString().Contains(searchTextParam)
                            ) {
-                            filtered.Add(def);
+                            lock (cachedSearchResults) {
+                                cachedSearchResults.Enqueue(def);
+                            }
                         } else if (searchKey != null) {
                             var text = searchKey(def).ToLower();
                             if (terms.All(term => text.Matches(term))) {
-                                filtered.Add(def);
+                                lock (cachedSearchResults) {
+                                    cachedSearchResults.Enqueue(def);
+                                }
                             }
                         }
                     }
                 } else {
-                    filtered = definitions.ToList();
+                    lock (cachedSearchResults) {
+                        cachedSearchResults = new Queue<Definition>(definitions);
+                    }
                 }
-                _matchCount = filtered.Count;
-                filteredOrderedDefinitions = filtered.OrderBy(sortKey);
-                UpdatePageCount();
-                UpdatePaginatedResults();
-                _updatePages = false;
+                _finishedSearch = true;
             }
             public void UpdatePageCount() {
                 if (SearchLimit > 0) {
@@ -290,7 +346,7 @@ namespace ModKit {
                 var offset = Math.Min(count, (_currentPage - 1) * limit);
                 limit = Math.Min(limit, Math.Max(count, count - limit));
                 Mod.Trace($"{_currentPage} / {_pageCount} count: {count} => offset: {offset} limit: {limit} ");
-                _pagedResults = filteredOrderedDefinitions.Skip(offset).Take(limit).ToArray();
+                _pagedResults = filteredDefinitions.Skip(offset).Take(limit).ToArray();
             }
         }
     }

--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -44,13 +44,16 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***Narria***) Added Dice Roll overrides for Skill checks only (thanks AlterAsc) and cleaned up the options a bit to make them more clear
 * (***Marria***) Search 'n Pick: Added counts to the collation categories
 * (***Narria***) Search 'n Pick: Fixed various duplicate value issues when using sub-categories
-* (***Narria***) Added ability to Inspect units in Party Editor (Data Viewer style)
 * (***Narria***) Added tweak in Loot Tab to allow you to loot locked items
 * (***Narria***) Added search to inspectors (Data Viewer)
-* (***Narria***) Fixed various issues with feature selection and parameterized features which means you can now add and remove a lot more things like Racial Herritage, Weapon Focus and Oracle Mystery Selections
-* (***Narria***) New spiffy UI for editing parameterized feats and feature selections
-* (***Narria***) Cleaned up layout of Party Editor for narrow and medium widths
-* (***ADDB***) Changed Browser to improve performance.
+* (***Narria*** and ***ADDB***) Completely reworked the Browser UI class and Party Editor
+  * (***Narria***) Implemented FeatureSelection and ParameterizedFeature for the new Browser, which means you can now add and remove a lot more things like Racial Herritage, Weapon Focus and Oracle Mystery Selections.
+  * (***Narria***) Fixed some Helper functions.
+  * (***Narria***) Added ability to Inspect units in Party Editor (Data Viewer style).
+  * (***Narria***) Cleaned up layout of Party Editor for narrow and medium widths.
+  * (***ADDB***) Changed Browser to improve performance.
+  * (***ADDB***) Port old Party Editor Browsers (Features, Buffs, Abilities, Spells) to the new Browser UI.
+  * (***ADDB***) Made search run async.
 * (***ADDB***) Fixed belt consumable feature.
 * (***ADDB***) Fixed visual size scaling breaking when using any sort of polymorph.
 * (***ADDB***) Allow Achievements now no longer wrongly awards achievements (achievements locked behind difficulty or main campaign or platform).

--- a/ToyBox/classes/MainUI/Browser/FactsEditor.cs
+++ b/ToyBox/classes/MainUI/Browser/FactsEditor.cs
@@ -52,7 +52,6 @@ namespace ToyBox {
         private static readonly Dictionary<UnitEntityData, Browser<Ability, BlueprintAbility>> AbilityBrowserDict = new();
         private static readonly Browser<FeatureSelectionEntry, BlueprintFeature> FeatureSelectionBrowser = new() { IsDetailBrowser = true };
         private static readonly Browser<IFeatureSelectionItem, IFeatureSelectionItem> ParameterizedFeatureBrowser = new() { IsDetailBrowser = true };
-        private static SimpleBlueprint _selectedDetailsBlueprint = null;
 
 
         public static void RowGUI<Item, Definition>(Item feature, Definition blueprint, UnitEntityData ch, Browser<Item, Definition> usedBrowser, List<Action> todo)

--- a/ToyBox/classes/MainUI/Browser/FactsEditor.cs
+++ b/ToyBox/classes/MainUI/Browser/FactsEditor.cs
@@ -18,7 +18,6 @@ using ModKit;
 using ModKit.DataViewer;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using UnityEngine;
 using static ModKit.UI;
@@ -84,13 +83,11 @@ namespace ToyBox {
                     increase.BlueprintActionButton(ch, blueprint, () => todo.Add(() => increase!.action(blueprint, ch, repeatCount)), 60);
                     Space(17);
                     remainingWidth -= 190;
-                }
-                else {
+                } else {
                     Space(190);
                     remainingWidth -= 190;
                 }
-            }
-            else {
+            } else {
                 Space(190);
                 remainingWidth -= 190;
             }
@@ -116,15 +113,13 @@ namespace ToyBox {
             var isEmpty = feature.Name.IsNullOrEmpty();
             if (isEmpty) {
                 name = feature.name;
-            }
-            else {
+            } else {
                 if (feature is BlueprintSpellbook spellbook)
                     return $"{spellbook.Name} - {spellbook.name}";
                 name = feature.Name;
                 if (name == "<null>" || name.StartsWith("[unknown key: ")) {
                     name = feature.name;
-                }
-                else if (Settings.showDisplayAndInternalNames) {
+                } else if (Settings.showDisplayAndInternalNames) {
                     name += $" : {feature.name.color(RGBA.darkgrey)}";
                 }
             }
@@ -141,8 +136,7 @@ namespace ToyBox {
                     Toggle("Show Tree", ref _showTree, Width(250));
                 }
                 treeEditor.OnGUI(ch, updateTree);
-            }
-            else {
+            } else {
                 browser.OnGUI(name,
                     fact,
                     GetBlueprints<Definition>,
@@ -171,7 +165,7 @@ namespace ToyBox {
                     (feature, blueprint) => ReflectionTreeView.DetailsOnGUI(feature != null ? feature : blueprint),
                     (unitFact, blueprint) => {
                         if (blueprint is BlueprintFeatureSelection featureSelection) {
-                            if (blueprint != _selectedDetailsBlueprint) FeatureSelectionBrowser.ReloadData();
+                            FeatureSelectionBrowser.needsReloadData |= browser.needsReloadData;
                             return (entry, f) => FeatureSelectionBrowser.OnGUI(
                                     $"{f.Name}-featureSelection",
                                     ch.FeatureSelectionEntries(featureSelection),
@@ -193,8 +187,7 @@ namespace ToyBox {
                                             10.space();
                                             Label($"{selectionEntry.data.Source.Blueprint.GetDisplayName()}",
                                                   250.width());
-                                        }
-                                        else
+                                        } else
                                             354.space();
                                         if (ch.HasFeatureSelection(featureSelection, f))
                                             ActionButton("Remove", () => {
@@ -206,7 +199,7 @@ namespace ToyBox {
                                                 browser.needsReloadData = true;
                                             }, 150.width());
                                         else
-                                            ActionButton("Add", () => { 
+                                            ActionButton("Add", () => {
                                                 ch.AddFeatureSelection(featureSelection, f);
                                                 FeatureSelectionBrowser.needsReloadData = true;
                                                 browser.needsReloadData = true;
@@ -214,10 +207,8 @@ namespace ToyBox {
                                         15.space();
                                         Label(f.GetDescription().StripHTML().green());
                                     }, null, null, 100);
-                        }
-                        else if (blueprint is BlueprintParametrizedFeature parametrizedFeature) {
-                            if (blueprint != _selectedDetailsBlueprint) ParameterizedFeatureBrowser.ReloadData();
-                            _selectedDetailsBlueprint = blueprint;
+                        } else if (blueprint is BlueprintParametrizedFeature parametrizedFeature) {
+                            ParameterizedFeatureBrowser.needsReloadData |= browser.needsReloadData;
                             return (_, item) => ParameterizedFeatureBrowser.OnGUI(
                              $"{item.Name}-parameterSelection",
                              ch.ParameterizedFeatureItems(parametrizedFeature),

--- a/ToyBox/classes/MainUI/PartyEditor/SpellsEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/SpellsEditor.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using ToyBox.classes.Infrastructure;
+using UnityEngine;
 using static ModKit.UI;
 
 
@@ -39,8 +40,7 @@ namespace ToyBox {
                         Label($"Merge Mythic".cyan(), AutoWidth());
                         25.space();
                         Label("When you get standalone mythic spellbooks you can merge them here.".green());
-                    }
-                    else {
+                    } else {
                         Label($"Merge Mythic:".cyan(), 175.width());
                         25.space();
                         foreach (var cl in mergeableClasses) {
@@ -59,8 +59,7 @@ namespace ToyBox {
                 if (editSpellbooks) {
                     spellbookEditCharacter = ch;
                     SpellBookBrowserOnGUI(ch, spellbooks, todo);
-                }
-                else {
+                } else {
                     var spellBrowser = SpellBrowserDict.GetValueOrDefault(ch, null);
                     if (spellBrowser == null) {
                         spellBrowser = new Browser<AbilityData, BlueprintAbility>();
@@ -123,8 +122,7 @@ namespace ToyBox {
                                         _startedLoading = false;
                                     }
                                 }
-                            }
-                            else {
+                            } else {
                                 availableSpells = new HashSet<BlueprintAbility>(spellbook.Blueprint.SpellList.GetSpells(selectedSpellbookLevel));
                             }
                             spells.ForEach((s) => availableSpells.Add(s.Blueprint));
@@ -140,8 +138,8 @@ namespace ToyBox {
                                 20.space();
                                 Toggle("Show Internal Names", ref Settings.showDisplayAndInternalNames);
                                 20.space();
-//                                Toggle("Show Inspector", ref Settings.factEditorShowInspector);
-//                                20.space();
+                                // Toggle("Show Inspector", ref Settings.factEditorShowInspector);
+                                // 20.space();
                                 if (Toggle("Search Descriptions", ref Settings.searchesDescriptions)) {
                                     spellBrowser.needsReloadData = true;
                                 }
@@ -150,18 +148,19 @@ namespace ToyBox {
                                     spellBrowser.needsReloadData = true;
                                     _startedLoading = true;
                                 }
+                                GUI.enabled = !spellBrowser.isSearching;
                                 Space(20);
-                                ActionButton("Add All", () => CasterHelpers.HandleAddAllSpellsOnPartyEditor(ch.Descriptor, spellBrowser.filteredOrderedDefinitions.Cast<BlueprintAbility>().ToList()), AutoWidth());
+                                ActionButton("Add All", () => CasterHelpers.HandleAddAllSpellsOnPartyEditor(ch.Descriptor, spellBrowser.filteredDefinitions.Cast<BlueprintAbility>().ToList()), AutoWidth());
                                 Space(20);
                                 ActionButton("Remove All", () => CasterHelpers.HandleAddAllSpellsOnPartyEditor(ch.Descriptor), AutoWidth());
+                                GUI.enabled = true;
                             }
                         },
                         (feature, blueprint) => FactsEditor.RowGUI(feature, blueprint, ch, spellBrowser, todo), (feature, blueprint) => {
                             ReflectionTreeView.DetailsOnGUI(blueprint);
                         }, null, 50, false, true, 100, 300, "", true);
                 }
-            }
-            else {
+            } else {
                 SpellBookBrowserOnGUI(ch, spellbooks, todo, true);
             }
             return todo;
@@ -189,8 +188,8 @@ namespace ToyBox {
                                 20.space();
                                 Toggle("Show Internal Names", ref Settings.showDisplayAndInternalNames, 200.width());
                                 20.space();
-//                                Toggle("Show Inspector", ref Settings.factEditorShowInspector, 150.width());
-//                                20.space();
+                                //                                Toggle("Show Inspector", ref Settings.factEditorShowInspector, 150.width());
+                                //                                20.space();
 
                                 if (Toggle("Search Descriptions", ref Settings.searchesDescriptions, 250.width())) {
                                     spellbookBrowser.needsReloadData = true;


### PR DESCRIPTION
- If the search query is changed; it will immediately start population with the results.
- If the search query stays the same but needsReloadData is called (e.g. by removing or adding an object through an action), it will keep showing the old results until the search is finished (because otherwise adding or removing would produce some minor stutters and looked since all results were new populated).
- Removed delay from entering a query until starting search (0.25s) since entering a new query now stops the prior search anyway.