### PR TITLE
Added an "Unlearned Scrolls" category in Enhanced Inventory

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -45,6 +45,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * (***Narria***) Made Selection Level a little more clear in FeatureSelection detail lists
 * (***Narria***) Further performance improvements to Party Editor search while you type
 * (***ADDB***) Added Button to remove all existing Swarm That Walks clones.
+* (***BuckAMayzing***) Added an "Unlearned Scrolls" category in Enhanced Inventory.
 ### Ver 1.5.0 
 * (***Narria***) Inventory Enhancements
   * Brought in some bits of ***Xenofell's*** lovely **Enhanced Inventory** to give a unified experience with Loot Rarity and to revive the mod which needed some love

--- a/ToyBox/classes/MainUI/Loot+Spellbook/EnhancedInventory.cs
+++ b/ToyBox/classes/MainUI/Loot+Spellbook/EnhancedInventory.cs
@@ -53,6 +53,7 @@ namespace ToyBox {
             [FilterCategories.UsableWithoutUMD] = ((int)ExpandedFilterType.UsableWithoutUMD, "Usable Without Magic Device Check"),
             [FilterCategories.CurrentEquipped] = ((int)ExpandedFilterType.CurrentEquipped, "Can Equip (Current Char)"),
             [FilterCategories.NonZeroPW] = ((int)ExpandedFilterType.NonZeroPW, "Non-zero price and weight"),
+            [FilterCategories.UnlearnedScrolls] = ((int)ExpandedFilterType.UnlearnedScrolls, "Unlearned Scrolls")
         };
 
         public static readonly RemappableInt FilterMapper = new RemappableInt();
@@ -135,6 +136,7 @@ namespace ToyBox {
         UsableWithoutUMD = 1 << 16,
         CurrentEquipped = 1 << 17,
         NonZeroPW = 1 << 18,
+        UnlearnedScrolls = 1 << 19,
 
         Default = Weapon |
             Armor |
@@ -152,7 +154,8 @@ namespace ToyBox {
             UnreadDocuments |
             UsableWithoutUMD |
             CurrentEquipped |
-            NonZeroPW,
+            NonZeroPW | 
+            UnlearnedScrolls,
     }
 
     [Flags]
@@ -188,6 +191,7 @@ namespace ToyBox {
         UsableWithoutUMD = 17,
         CurrentEquipped = 18,
         NonZeroPW = 19,
+        UnlearnedScrolls = 20,
     }
 
     public enum ExpandedSorterType

--- a/ToyBox/classes/MonkeyPatchin/Loot+Spellbook/ItemsFilter.cs
+++ b/ToyBox/classes/MonkeyPatchin/Loot+Spellbook/ItemsFilter.cs
@@ -79,6 +79,13 @@ namespace ToyBox.Inventory {
             else if (expanded_filter == ExpandedFilterType.NonZeroPW) {
                 __result = item.Blueprint.SellPrice > 0 && item.Blueprint.Weight > 0.0f;
             }
+            else if (expanded_filter == ExpandedFilterType.UnlearnedScrolls)
+            {
+                var scroll = item.Blueprint.GetComponent<CopyScroll>();
+                var unit = Kingmaker.Game.Instance.SelectionCharacter.CurrentSelectedCharacter;
+                var canCopy = scroll?.CanCopy(item, unit) ?? false;
+                __result = unit != null && canCopy;
+            }
             else {
                 // Original call - proceed as normal.
                 return true;


### PR DESCRIPTION
Well, I have no idea what the "Unlearned" category is supposed to do, but it simply doesn't do what we expect it to. I don't know how one "learns" a +5 Full Plate.

It seems that the "Unlearned" category, for some reason, returns armor and (only sometimes) weapons of the same type that are currently equipped on the character. I have no idea what's up with it. 

Perhaps is related to the Prestdigipainter? 