### PR TITLE
Patched an issue that could cause a crash if a shared string was referenced incorrectly in other mods

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -38,6 +38,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
 * **Quest Resolution**: this allows you to view your active quests and advance them as needed to work around bugs or skip quests you don't want to do.  Be warned this may break your game progression if used carelessly.
 ### Ver 1.5.2 (Comming Soon)
  * (***ADDB***) Initial support for localization
+ * (***BuckAMayzing***) Patched an issue that could cause a crash if a shared string was referenced incorrectly in other mods.
 **ToyBox 1.5.2** ***Experimental Preview*** ****
 ### Ver 1.5.1
 * (***Narria***) **Quality of Life: Enhanced Map**: 

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Localization.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Localization.cs
@@ -27,5 +27,13 @@ namespace ToyBox.BagOfPatches {
                 //unit2.LocalizedName.String = localizedString;
             }
         }
+
+        [HarmonyPatch(typeof(LocalizedString), nameof(LocalizedString.GetActualKey))]
+        public class Patch_ActualKeyBug
+        {
+            [HarmonyPatch]
+            [HarmonyPostfix]
+            public static string Postfix(string original) => original ?? "";
+        }
     }
 }


### PR DESCRIPTION
This is just a bit of defensive coding. In a normal scenario, `GetActualKey` can never be null. But if a mod author doesn't share strings correctly, it can become null. This will just force it to an empty string. I can put another value in here if we prefer; I'd just maybe avoid `"<null>"` since it's already used and confuse a mod author if they see it. Maybe `"<ToyboxNull>"` to make it clear where it came from?