### PR TITLE
Prevented bulk sell from selling equipped items

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -52,6 +52,7 @@ WARNING: this tool can both miraculously fix your broken progression or it can b
  * (***Narria***) Fixed other crashers introduced by c#11
  * (***Narria***) **Fixed bug where loot slot filtering was being applied to things outside of inventory**
  * (***Narria***) Added work around for issue of game double calling SelectClass.Apply leading to multiclass levels being added more than once during character creation **Please test out and report any issues you find in gestalt/multiclassing**
+ * (***BuckAMayzing***) Fixed issue with Bulk Sell unintentionally selling items that were still equipped on characters.
 ### Ver 1.5.2
  * (***Narria***) **UI Reorg** Moved UI Enhancements into new top level **Enhanced UI** tab and the Loot tab is now just for loot related stuff
  * (***Narria***) Quality of Life: **Click On Equip Slots To Filter Inventory** this lets you filter the inventory to just the items that can be equipped by the slot you click on.

--- a/ToyBox/classes/MonkeyPatchin/Vendor/BulkSellLogic.cs
+++ b/ToyBox/classes/MonkeyPatchin/Vendor/BulkSellLogic.cs
@@ -310,6 +310,7 @@ namespace ToyBox {
                     vanillaMassSell = VendorHelper.IsAppropriateForMassSelling(item),
                     numberToSell = BulkSellLogic.canBulkSellCount(item)
                 })
+                .Where(item => item.item.Owner == null)
                 .Where(item => item.vanillaMassSell || item.numberToSell > 0)
                 .Select(item => (new { item.item, quantity = item.vanillaMassSell ? -1 : item.numberToSell }))
                 .ToList();


### PR DESCRIPTION
This is just a minor change. In theory, it should rarely happen, as players mostly equip items they want to keep, but it should be fixed nonetheless.