### PR TITLE
fixing nullrefs in GetActualSpellsLearnedForClass, using LevelUpController

### DIFF
--- a/ToyBox/classes/Infrastructure/CasterHelpers.cs
+++ b/ToyBox/classes/Infrastructure/CasterHelpers.cs
@@ -165,7 +165,7 @@ namespace ToyBox.classes.Infrastructure {
             selectedSpellbook.RemoveSpellsOfLevel(level);
         }
 
-#if true // TODO: the else case if a patch that fixes the level for spontaneous spell casters learning scrolls
+#if false // TODO: the else case if a patch that fixes the level for spontaneous spell casters learning scrolls
         public static int GetActualSpellsLearnedForClass(UnitDescriptor unit, Spellbook spellbook, int level) {
             Mod.Trace($"GetActualSpellsLearnedForClass - unit: {unit?.CharacterName} spellbook: {spellbook?.Blueprint.DisplayName} level:{level}");
             // Get all +spells known facts for this spellbook's class so we can ignore them when getting spell counts
@@ -193,7 +193,7 @@ namespace ToyBox.classes.Infrastructure {
             return known.Count;
         }
 #else
-       public static int GetActualSpellsLearnedForClass(UnitDescriptor unit, Spellbook spellbook, int level) {
+       public static int GetActualSpellsLearnedForClass(UnitDescriptor unit, Spellbook spellbook, int level, UnitDescriptor baseUnit = null) {
             Mod.Trace($"GetActualSpellsLearnedForClass - unit: {unit?.CharacterName} spellbook: {spellbook?.Blueprint.DisplayName} level:{level}");
             // Get all +spells known facts for this spellbook's class so we can ignore them when getting spell counts
             var spellsToIgnore = unit.Facts.List.SelectMany(x =>
@@ -201,9 +201,8 @@ namespace ToyBox.classes.Infrastructure {
                 .Where(x => x.CharacterClass == spellbook.Blueprint.CharacterClass && (x.Archetype == null || unit.Progression.IsArchetype(x.Archetype))).Select(y => y.Spell)
                 .ToList();
             Spellbook spellbookOfNormalUnit = null;
-            if (unit.TryGetPartyMemberForLevelUpVersion(out var ch)) { // get the real units spellbook, the levelup version does not contain flags like CopiedFromScroll
-                if (ch?.Spellbooks?.Count() > 0)
-                    spellbookOfNormalUnit = ch.Spellbooks.First(s => s.Blueprint == spellbook.Blueprint);
+            if (baseUnit != null) { // get the real units spellbook, the levelup version does not contain flags like CopiedFromScroll
+                spellbookOfNormalUnit = baseUnit.Spellbooks?.FirstOrDefault(s => s.Blueprint == spellbook.Blueprint);
             }
             return GetActualSpellsLearned(spellbook, level, spellsToIgnore, spellbookOfNormalUnit);
         }
@@ -224,18 +223,20 @@ namespace ToyBox.classes.Infrastructure {
             Func<AbilityData, bool> normalSpellbookCondition = x => true;
             if (spellbookOfNormalUnit != null) {
                 var normalSpellsOfLevel = spellbookOfNormalUnit.SureKnownSpells(level);
-                normalSpellbookCondition = x => {
-                    var sp = normalSpellsOfLevel.First(a => a.Blueprint == x.Blueprint);
-                    if (sp == null)
-                        return true;
-                    return !sp.IsTemporary
-                        && !sp.CopiedFromScroll
-                        && !sp.IsFromMythicSpellList
-                        && sp.SourceItem == null
-                        && sp.SourceItemEquipmentBlueprint == null
-                        && sp.SourceItemUsableBlueprint == null
-                        && !sp.IsMysticTheurgeCombinedSpell;
-                };
+                if (normalSpellsOfLevel != null) {
+                    normalSpellbookCondition = x => {
+                        var sp = normalSpellsOfLevel.FirstOrDefault(a => a.Blueprint == x.Blueprint);
+                        if (sp == null)
+                            return true;
+                        return !sp.IsTemporary
+                            && !sp.CopiedFromScroll
+                            && !sp.IsFromMythicSpellList
+                            && sp.SourceItem == null
+                            && sp.SourceItemEquipmentBlueprint == null
+                            && sp.SourceItemUsableBlueprint == null
+                            && !sp.IsMysticTheurgeCombinedSpell;
+                    };
+                }
             }
             var known = spellbook.SureKnownSpells(level)
                 .Where(x => !x.IsTemporary

--- a/ToyBox/classes/MonkeyPatchin/Multiclass/LevelUP+Multiclass.cs
+++ b/ToyBox/classes/MonkeyPatchin/Multiclass/LevelUP+Multiclass.cs
@@ -199,7 +199,7 @@ namespace ToyBox.Multiclass {
                     for (var index = 0; index <= 10; ++index) {
                         var spellsKnown = spellbook1.Blueprint.SpellsKnown;
                         var expectedCount = spellsKnown.GetCount(casterLevelAfter, index);
-                        var actual = CasterHelpers.GetActualSpellsLearnedForClass(unit, spellbook1, index);
+                        var actual = CasterHelpers.GetActualSpellsLearnedForClass(unit, spellbook1, index, Game.Instance.LevelUpController.m_BaseUnit);
                         int learnabl = spellbook1.GetSpellsLearnableOfLevel(index).Count();
                         int spelladd = Math.Max(0, Math.Min(expectedCount - actual, learnabl));
 #if DEBUG


### PR DESCRIPTION
Alternative fix for the CopiedFromScroll issue.
Fixing the Nullrefs and using `Game.Instance.LevelUpController.m_BaseUnit`
Alternatives are #923 and #924 