### PR TITLE
Fixed a bug regarding companion gestalts

### DIFF
--- a/ToyBox/classes/MonkeyPatchin/Multiclass/MultipleClasses.cs
+++ b/ToyBox/classes/MonkeyPatchin/Multiclass/MultipleClasses.cs
@@ -65,10 +65,13 @@ namespace ToyBox.Multiclass {
                     if (unit.TryGetPartyMemberForLevelUpVersion(out var ch)
                         && ch.TryGetClass(state.SelectedClass, out var cl)
                         && unit != ch.Descriptor()
-                        && state.NextClassLevel <= cl.Level
                         ) {
-                        Mod.Debug($"SelectClass_Apply_Patch, unit: {unit.CharacterName.orange()} isCH: {unit == ch.Descriptor()}) - skip - lvl:{state.NextClassLevel} vs {cl.Level} ".green());
-                        return;
+                        var classLevelLimit = unit.Blueprint.GetComponent<ClassLevelLimit>().LevelLimit;
+                        if (state.NextClassLevel <= classLevelLimit) {
+                            Mod.Debug($"SelectClass_Apply_Patch, unit: {unit.CharacterName.orange()} isCH: {unit == ch.Descriptor()}) - skip - lvl:{state.NextClassLevel} vs {classLevelLimit} ".green());
+                            Mod.Debug($"classLevelLimit: {classLevelLimit}");
+                            return;
+                        }
                     }
                     // get multi-class setting
                     var isPet = unit.Unit?.IsPet ?? false;


### PR DESCRIPTION
Okay, in theory, this bug would only pop up if you were respeccing (respecing?) a companion. The issue with the old code was that `cl.Level` would just be whatever the character's level was at the time of respec, so if the character was level 20, you couldn't gestalt at all if you used their default class.

What this code does is just skip the predefined levels, which should be defined in the `ClassLevelLimit` blueprint. In my testing, this fixed the bug for Lann. I haven't thoroughly tested this, but I don't know what other test cases are prudent here either.