### PR TITLE
Fix issue with gestalt mercenaries

### DIFF
--- a/ToyBox/classes/MonkeyPatchin/Multiclass/MultipleClasses.cs
+++ b/ToyBox/classes/MonkeyPatchin/Multiclass/MultipleClasses.cs
@@ -66,7 +66,7 @@ namespace ToyBox.Multiclass {
                         && ch.TryGetClass(state.SelectedClass, out var cl)
                         && unit != ch.Descriptor()
                         ) {
-                        var classLevelLimit = unit.Blueprint.GetComponent<ClassLevelLimit>().LevelLimit;
+                        var classLevelLimit = unit.Blueprint.GetComponent<ClassLevelLimit>()?.LevelLimit ?? 0;
                         if (state.NextClassLevel <= classLevelLimit) {
                             Mod.Debug($"SelectClass_Apply_Patch, unit: {unit.CharacterName.orange()} isCH: {unit == ch.Descriptor()}) - skip - lvl:{state.NextClassLevel} vs {classLevelLimit} ".green());
                             Mod.Debug($"classLevelLimit: {classLevelLimit}");

--- a/ToyBox/classes/MonkeyPatchin/Multiclass/MultipleClasses.cs
+++ b/ToyBox/classes/MonkeyPatchin/Multiclass/MultipleClasses.cs
@@ -66,6 +66,8 @@ namespace ToyBox.Multiclass {
                         && ch.TryGetClass(state.SelectedClass, out var cl)
                         && unit != ch.Descriptor()
                         ) {
+                        //ClassLevelLimit is the number of classes that a companion comes with by default.
+                        //This is null for mercenaries, so we have to default it back to 0 for them.
                         var classLevelLimit = unit.Blueprint.GetComponent<ClassLevelLimit>()?.LevelLimit ?? 0;
                         if (state.NextClassLevel <= classLevelLimit) {
                             Mod.Debug($"SelectClass_Apply_Patch, unit: {unit.CharacterName.orange()} isCH: {unit == ch.Descriptor()}) - skip - lvl:{state.NextClassLevel} vs {classLevelLimit} ".green());


### PR DESCRIPTION
This is a regression that I introduced. I noticed it while I was testing. 

Mercenaries are companions but have no ClassLevelLimit, so they were broken. I'll release a preview fix of this as well.

I didn't add patch notes for this one, as it falls under the already noted gestalt companions fix.