### PR TITLE
Adjusted the logic of Recruit Multiplier

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -97,6 +97,7 @@
 * (***Narria***) dialog preview now shows conditions for answers too
 * (***BuckAMayzing***) Gestalt Companion fix
 * (***BuckAMayzing***) Mercenary Gestalt fix
+* (***ADDB***) Adjusted the logic of Recruit Multiplier 
 * (***ADDB***) Add new Bindable Action Buttons for Loot Revealers
 * (***ADDB***) Prevent Mod from overriding Build Points when not changed in the settings
 * (***ADDB***) Added toggle to disable traps

--- a/ToyBox/classes/MonkeyPatchin/BagOfPatches/Crusade.cs
+++ b/ToyBox/classes/MonkeyPatchin/BagOfPatches/Crusade.cs
@@ -117,8 +117,8 @@ namespace ToyBox.classes.MonkeyPatchin.BagOfPatches {
             }
         }
 
-        [HarmonyPatch(typeof(ArmyRecruitsManager), nameof(ArmyRecruitsManager.Increase))]
-        private static class ArmyRecruitsManager_Patch {
+        [HarmonyPatch(typeof(ArmyRecruitsManager), nameof(ArmyRecruitsManager.Recruit))]
+        private static class ArmyRecruitsManager_Recruit_Patch {
             private static void Prefix(ref int count) => count = Mathf.RoundToInt(count * Settings.recruitmentMultiplier);
         }
 


### PR DESCRIPTION
Closes #947 
The original multiplier applied when troops were refreshed. This one applies when troops are multiplied