### PR TITLE
Maybe fix unclean? ModKitSetting causing crash

### DIFF
--- a/ModKit/ModKit/SettingsController.cs
+++ b/ModKit/ModKit/SettingsController.cs
@@ -1,9 +1,9 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.IO;
 using System.Reflection;
-using static UnityModManagerNet.UnityModManager;
-using System;
 using System.Xml.Serialization;
+using static UnityModManagerNet.UnityModManager;
 
 namespace ModKit {
     public interface IUpdatableSettings {
@@ -43,7 +43,7 @@ namespace ModKit {
                 try {
                     var userSettings = JsonConvert.DeserializeObject<T>(reader.ReadToEnd());
                     if (userSettings is IUpdatableSettings updatableSettings) updatableSettings.AddMissingKeys((IUpdatableSettings)settings);
-                    settings = userSettings;
+                    settings = userSettings ?? new();
                 }
                 catch {
                     Mod.Error("Failed to load user settings. Settings will be rebuilt.");

--- a/ModKit/ModKit/SettingsController.cs
+++ b/ModKit/ModKit/SettingsController.cs
@@ -42,7 +42,7 @@ namespace ModKit {
                 using var reader = File.OpenText(userPath);
                 try {
                     var userSettings = JsonConvert.DeserializeObject<T>(reader.ReadToEnd());
-                    if (userSettings is IUpdatableSettings updatableSettings) updatableSettings.AddMissingKeys((IUpdatableSettings)settings);
+                    if (userSettings is IUpdatableSettings updatableSettings) updatableSettings?.AddMissingKeys((IUpdatableSettings)settings);
                     settings = userSettings ?? new();
                 }
                 catch {


### PR DESCRIPTION
When user loaded into Main Menu ToyBox was disabled; Log showed this:
![grafik](https://github.com/cabarius/ToyBox/assets/62178123/dabaa904-b70a-4248-81e2-874998a667da)
which is this method:
![grafik](https://github.com/cabarius/ToyBox/assets/62178123/e2d801cc-474d-410c-bd40-05b0cddfaa20)
Expected that NullReference could only be related to ModKitSettings; meaning the load probably returned a Null object. 
No log entry was created so it didn't enter the catch block of the code section (where I did the changes of this commit)
Since the issue was fixed by reinstalling ToyBox I expect it really was related to the settings file so I'll add some additional Null checking just in case; would've really liked to see that setting file first though.
