### PR TITLE
Also show activatable abilities

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -76,11 +76,11 @@
 ### ToyBox Rogue - Ver 1.5.8 (Coming Soon)
 **ToyBox Rogue - Ver 1.5.8 -** ***Sh0dan*** **Preview Version 1.5.7a** built for 0.2.1ah
 * (***ADDB***) Fixed weird behaviour when changing stats using the Textfield.
-
 ### ToyBox Wrath - Ver 1.5.8 (Coming Soon)
 **ToyBox Wrath - Ver 1.5.8 - Preview Version 1.5.7a** built for 2.1.5r
 * (***ADDB***) Ride everything now really allows riding everything. Looks ridiculous but still.
 * (***ADDB***) Fixed weird behaviour when changing stats using the Textfield.
+* * (***ifarmpandas***) Added ActivatableAbilities to "Abilities" button in party editor. 
 ### ToyBox Rogue - Ver 1.5.7 (built for 0.2.1ah)
 * (***ADDB***) Added all localization keys to allow full localization.
 ### ToyBox Wrath - Ver 1.5.7 (built for 2.1.5r)

--- a/ToyBox/classes/MainUI/PartyEditor/PartyEditor.cs
+++ b/ToyBox/classes/MainUI/PartyEditor/PartyEditor.cs
@@ -323,7 +323,7 @@ namespace ToyBox {
                     todo = FactsEditor.OnGUI(ch, ch.Descriptor().Buffs.Enumerable.ToList());
                 }
                 if (ch == selectedCharacter && selectedToggle == ToggleChoice.Abilities) {
-                    todo = FactsEditor.OnGUI(ch, ch.Descriptor().Abilities.Enumerable.ToList());
+                    todo = FactsEditor.OnGUI(ch, ch.Descriptor().Abilities.Enumerable, ch.Descriptor.ActivatableAbilities.Enumerable);
                 }
 #if Wrath
                 if (ch == selectedCharacter && selectedToggle == ToggleChoice.Spells) {


### PR DESCRIPTION
Party editor "Abilities" button will show both abilities and activatables.
Modified OnGUI to generate actions for runtime derived types in list instead of a base type defined at compile time.

Example below:

[power attack search](https://cdn.discordapp.com/attachments/791053285657542666/1169692126041341952/image.png?ex=655653ae&is=6543deae&hm=7d298bd01ee3a6764e1323f3fcd02b7795b3825ad0fde32906644a51002867e2&)