### PR TITLE
Catch errors to prevent broken menu on console view

### DIFF
--- a/ToyBox/ReadMe.md
+++ b/ToyBox/ReadMe.md
@@ -80,7 +80,8 @@
 **ToyBox Wrath - Ver 1.5.8 - Preview Version 1.5.7a** built for 2.1.5r
 * (***ADDB***) Ride everything now really allows riding everything. Looks ridiculous but still.
 * (***ADDB***) Fixed weird behaviour when changing stats using the Textfield.
-* * (***ifarmpandas***) Added ActivatableAbilities to "Abilities" button in party editor. 
+* * (***ifarmpandas***) Added ActivatableAbilities to "Abilities" button in party editor.
+* (***evandixon***) Fix unusable map screen on console view (e.g. Steam Deck)
 ### ToyBox Rogue - Ver 1.5.7 (built for 0.2.1ah)
 * (***ADDB***) Added all localization keys to allow full localization.
 ### ToyBox Wrath - Ver 1.5.7 (built for 2.1.5r)


### PR DESCRIPTION
Fixes #999, which is real annoying.

A better solution would be to update UIUtilities to select the appropriate ConsoleView transforms instead of PCView. I poked around with that a little but concluded I don't know what I'm doing. I figure this is the safest and simplest solution to just fix the map.

Tested using a laptop with a Logitech Gamepad F310 that was able to repro the issue, though I'll put it through some _real_ testing later on a steam deck.